### PR TITLE
Update calico install docs to use manifest which supports eni interfaces

### DIFF
--- a/doc_source/calico.md
+++ b/doc_source/calico.md
@@ -7,20 +7,19 @@
 1. Apply the Calico manifest from the [`aws/amazon-vpc-cni-k8s` GitHub project](https://github.com/aws/amazon-vpc-cni-k8s)\. This manifest creates daemon sets in the `kube-system` namespace\.
 
    ```
-   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.0.0/config/v1.0/aws-k8s-cni-calico.yaml
+   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/master/config/v1.0/calico.yaml
    ```
 
-1. Watch the `kube-system` daemon sets and wait for the `aws-node` and `calico-node` daemon sets to have the `DESIRED` number of pods in the `READY` state\. When this happens, Calico is working\.
+1. Watch the `kube-system` daemon sets and wait for the `calico-node` daemonset to have the `DESIRED` number of pods in the `READY` state\. When this happens, Calico is working\.
 
    ```
-   kubectl get daemonsets --namespace=kube-system
+   kubectl get daemonset calico-node --namespace=kube-system
    ```
 
    Output:
 
    ```
    NAME          DESIRED   CURRENT   READY     UP-TO-DATE   AVAILABLE   NODE SELECTOR   AGE
-   aws-node      3         3         3         3            3           <none>          38s
    calico-node   3         3         3         3            3           <none>          38s
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

No issue, but this is a takeover of #6 which @bcreane asked me to submit since he's out for the next 2 weeks.

*Description of changes:*

Update the install procedure for new Calico clusters.

The previous manifest (v1.0.0) included both the Calico daemonset and a modified aws-node daemonset.

The new manifest includes a newer release of Calico that does not need to modify the underlying aws-node daemonset.

#6 was a bit more complicated because it tried to cover the update procedure from the previous manifest to the new manifest. I'd prefer we keep the install docs short and sweet, and if necessary, put upgrade instructions in a new doc. I'm open to doing so as part of this PR if maintainers can advise where that should go.

I'm also not sure if the new manifest needs to be released somehow, since it is currently only in master over at https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.0/calico.yaml

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
