### PR TITLE
Update service_IAM_role.md

### DIFF
--- a/doc_source/service_IAM_role.md
+++ b/doc_source/service_IAM_role.md
@@ -1,129 +1,19 @@
 # Amazon EKS Service IAM Role<a name="service_IAM_role"></a>
 
-Amazon EKS makes calls to other AWS services on your behalf to manage the resources that you use with the service\. Before you can use the service, you must have an IAM policy and role that provides the necessary permissions to Amazon EKS\.
+Amazon EKS makes calls to other AWS services on your behalf to manage the resources that you use with the service\. Before you can use the service, you must create an IAM role that implements the following IAM policies:
 
-The `AWSServiceRoleForAmazonEKS` IAM role uses the following IAM policies:
-+ `AmazonEKSServicePolicy`
-+ `AmazonEKSClusterPolicy`
+* [`AmazonEKSServicePolicy`](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AmazonEKSServicePolicy$jsonEditor)
+* [`AmazonEKSClusterPolicy`](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AmazonEKSClusterPolicy$jsonEditor)
 
-The `AmazonEKSServicePolicy` policy for the `AWSServiceRoleForAmazonEKS` IAM role is shown below\.
+Before you create this new role, you may wish to first check if it exists and verify that it is configured correctly. 
 
-```
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "ec2:AttachNetworkInterface",
-        "ec2:CreateNetworkInterface",
-        "ec2:CreateNetworkInterfacePermission",
-        "ec2:DeleteNetworkInterface",
-        "ec2:DeleteNetworkInterfacePermission",
-        "ec2:Describe*",
-        "ec2:DetachNetworkInterface",
-        "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-        "elasticloadbalancing:DeregisterTargets",
-        "elasticloadbalancing:Describe*",
-        "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-        "elasticloadbalancing:RegisterTargets",
-        "route53:ChangeResourceRecordSets",
-        "route53:CreateHealthCheck",
-        "route53:DeleteHealthCheck",
-        "route53:Get*",
-        "route53:List*",
-        "route53:UpdateHealthCheck",
-        "servicediscovery:DeregisterInstance",  
-        "servicediscovery:Get*",
-        "servicediscovery:List*",
-        "servicediscovery:RegisterInstance",
-        "servicediscovery:UpdateInstanceCustomHealthStatus"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-The `AmazonEKSClusterPolicy` policy for the `AWSServiceRoleForAmazonEKS` IAM role is shown below\.
-
-```
-{
-    "Version": "2012-10-17",
-    "Statement": [
-        {
-            "Effect": "Allow",
-            "Action": [
-                "autoscaling:DescribeAutoScalingGroups",
-                "autoscaling:UpdateAutoScalingGroup",
-                "ec2:AttachVolume",
-                "ec2:AuthorizeSecurityGroupIngress",
-                "ec2:CreateRoute",
-                "ec2:CreateSecurityGroup",
-                "ec2:CreateTags",
-                "ec2:CreateVolume",
-                "ec2:DeleteRoute",
-                "ec2:DeleteSecurityGroup",
-                "ec2:DeleteVolume",
-                "ec2:DescribeInstances",
-                "ec2:DescribeRouteTables",
-                "ec2:DescribeSecurityGroups",
-                "ec2:DescribeSubnets",
-                "ec2:DescribeVolumes",
-                "ec2:DescribeVolumesModifications",
-                "ec2:DescribeVpcs",
-                "ec2:DetachVolume",
-                "ec2:ModifyInstanceAttribute",
-                "ec2:ModifyVolume",
-                "ec2:RevokeSecurityGroupIngress",
-                "elasticloadbalancing:AddTags",
-                "elasticloadbalancing:ApplySecurityGroupsToLoadBalancer",
-                "elasticloadbalancing:AttachLoadBalancerToSubnets",
-                "elasticloadbalancing:ConfigureHealthCheck",
-                "elasticloadbalancing:CreateListener",
-                "elasticloadbalancing:CreateLoadBalancer",
-                "elasticloadbalancing:CreateLoadBalancerListeners",
-                "elasticloadbalancing:CreateLoadBalancerPolicy",
-                "elasticloadbalancing:CreateTargetGroup",
-                "elasticloadbalancing:DeleteListener",
-                "elasticloadbalancing:DeleteLoadBalancer",
-                "elasticloadbalancing:DeleteLoadBalancerListeners",
-                "elasticloadbalancing:DeleteTargetGroup",
-                "elasticloadbalancing:DeregisterInstancesFromLoadBalancer",
-                "elasticloadbalancing:DeregisterTargets",
-                "elasticloadbalancing:DescribeListeners",
-                "elasticloadbalancing:DescribeLoadBalancerAttributes",
-                "elasticloadbalancing:DescribeLoadBalancerPolicies",
-                "elasticloadbalancing:DescribeLoadBalancers",
-                "elasticloadbalancing:DescribeTargetGroupAttributes",
-                "elasticloadbalancing:DescribeTargetGroups",
-                "elasticloadbalancing:DescribeTargetHealth",
-                "elasticloadbalancing:DetachLoadBalancerFromSubnets",
-                "elasticloadbalancing:ModifyListener",
-                "elasticloadbalancing:ModifyLoadBalancerAttributes",
-                "elasticloadbalancing:ModifyTargetGroup",
-                "elasticloadbalancing:ModifyTargetGroupAttributes",
-                "elasticloadbalancing:RegisterInstancesWithLoadBalancer",
-                "elasticloadbalancing:RegisterTargets",
-                "elasticloadbalancing:SetLoadBalancerPoliciesForBackendServer",
-                "elasticloadbalancing:SetLoadBalancerPoliciesOfListener",
-                "kms:DescribeKey"
-            ],
-            "Resource": "*"
-        }
-    ]
-}
-```
-
-You can use the following procedure to check and see if your account already has the Amazon EKS service role and to attach the managed IAM policy if needed\.<a name="procedure_check_service_role"></a>
-
-**To check for the `AWSServiceRoleForAmazonEKS` in the IAM console**
+## Check for an existing `AWSServiceRoleForAmazonEKS` role in the IAM console
 
 1. Open the IAM console at [https://console\.aws\.amazon\.com/iam/](https://console.aws.amazon.com/iam/)\.
 
 1. In the navigation pane, choose **Roles**\. 
 
-1. Search the list of roles for `AWSServiceRoleForAmazonEKS`\. If the role does not exist, see [Create your Amazon EKS Service Role](getting-started.md#role-create) to create the role\. If the role does exist, select the role to view the attached policies\.
+1. Search the list of roles for `AWSServiceRoleForAmazonEKS`\. If the role exists, select the role to view the attached policies\.
 
 1. Choose **Permissions**\.
 
@@ -148,14 +38,33 @@ You can use the following procedure to check and see if your account already has
    }
    ```
 
-**To create your Amazon EKS service role**
+If you were unable to verify the presence of an existing ```AWSServiceRoleForAmazonEKS``` role, one can easily be created via the console or CloudFormation.
 
-1. Open the IAM console at [https://console\.aws\.amazon\.com/iam/](https://console.aws.amazon.com/iam/)\.
+## Creating the AWSServiceRoleForAmazonEKS role
 
-1. Choose **Roles**, then **Create role**\.
+The ```AWSServiceRoleForAmazonEKS``` role can be created [through the console](getting-started.md#role-create), or via a CloudFormation template:
 
-1. Choose **EKS** from the list of services, then **Allows Amazon EKS to manage your clusters on your behalf** for your use case, then **Next: Permissions**\.
+```
+AWSTemplateFormatVersion: 2010-09-09
 
-1. Choose **Next: Review**\.
+Description: Creates AWS EKS Service Role
 
-1. For **Role name**, enter a unique name for your role, such as `eksServiceRole`, then choose **Create role**\.
+Resources:
+  AWSEKSServiceRole:
+    Type: AWS::IAM::Role
+    Properties:
+      RoleName: AWSServiceRoleForAmazonEKS
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+        -
+          Effect: Allow
+          Principal:
+            Service:
+              - eks.amazonaws.com
+          Action:
+            - sts:AssumeRole
+      ManagedPolicyArns:
+        - arn:aws:iam::aws:policy/AmazonEKSClusterPolicy
+        - arn:aws:iam::aws:policy/AmazonEKSServicePolicy
+```


### PR DESCRIPTION
Cleaned the document a bit by removing explicit reference to the policies and instead linking to them.  Point to a single source of creating the role via the console, and include an alternative method of creating the role via CloudFormation.  CloudFormation script provided by @palsarma




By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
