### PR TITLE
Correction to sec-group-reqs.md

### DIFF
--- a/doc_source/sec-group-reqs.md
+++ b/doc_source/sec-group-reqs.md
@@ -4,28 +4,28 @@ If you create your VPC and worker node groups with the AWS CloudFormation templa
 
 The security group for the worker nodes and the security group for the control plane communication to the worker nodes have been set up to prevent communication to privileged ports in the worker nodes\. If your applications require added inbound or outbound access from the control plane or worker nodes, you must add these rules to the security groups associated with your cluster\. For more information, see [Security Groups for Your VPC](http://docs.aws.amazon.com/vpc/latest/userguide/VPC_SecurityGroups.html) in the *Amazon VPC User Guide*\.
 
-**Note**  
-To allow proxy functionality on privileged ports or to run the CNCF conformance tests yourself, you must edit the security groups for your control plane and the worker nodes\. The security group on the worker nodes side need to allow inbound access for ports 0\-66535 from the control plane, and the control plane side needs to allow outbound access to the worker nodes on ports 0\-65535\.
+**Note**
+To allow proxy functionality on privileged ports or to run the CNCF conformance tests yourself, you must edit the security groups for your control plane and the worker nodes\. The security group on the worker nodes side need to allow inbound access for ports 0\-65535 from the control plane, and the control plane side needs to allow outbound access to the worker nodes on ports 0\-65535\.
 
 The following tables show the minimum required and recommended security group settings for the control plane and worker node security groups for your cluster:
 
 
-**Control Plane Security Group**  
+**Control Plane Security Group**
 
-|  | Protocol | Port Range | Source | Destination | 
-| --- | --- | --- | --- | --- | 
-| Minimum inbound traffic |  TCP  |  443  |  Worker node security group  |  | 
-| Recommended inbound traffic |  TCP  |  443  |  Worker node security group  |  | 
-| Minimum outbound traffic |  TCP  |  10250  |  |  Worker node security group  | 
-| Recommended outbound traffic |  TCP  |  1025\-65535  |  |  Worker node security group  | 
+|  | Protocol | Port Range | Source | Destination |
+| --- | --- | --- | --- | --- |
+| Minimum inbound traffic |  TCP  |  443  |  Worker node security group  |  |
+| Recommended inbound traffic |  TCP  |  443  |  Worker node security group  |  |
+| Minimum outbound traffic |  TCP  |  10250  |  |  Worker node security group  |
+| Recommended outbound traffic |  TCP  |  1025\-65535  |  |  Worker node security group  |
 
 
-**Worker Node Security Group**  
+**Worker Node Security Group**
 
-|  | Protocol | Port Range | Source | Destination | 
-| --- | --- | --- | --- | --- | 
-| Minimum inbound traffic \(from other worker nodes\) |  Any protocol you expect your worker nodes to use for inter\-worker communication  |  Any ports you expect your worker nodes to use for inter\-worker communication  |  Worker node security group  |  | 
-| Minimum inbound traffic \(from control plane\) |  TCP  |  10250  |  Control plane security group  |  | 
-| Recommended inbound traffic |  All TCP  |  All 1025\-65535  |  Worker node security group Control plane security group  |  | 
-| Minimum outbound traffic |  TCP  |  443  |  |  Control plane security group  | 
-| Recommended outbound traffic |  All  |  All  |  |  0\.0\.0\.0/0  | 
+|  | Protocol | Port Range | Source | Destination |
+| --- | --- | --- | --- | --- |
+| Minimum inbound traffic \(from other worker nodes\) |  Any protocol you expect your worker nodes to use for inter\-worker communication  |  Any ports you expect your worker nodes to use for inter\-worker communication  |  Worker node security group  |  |
+| Minimum inbound traffic \(from control plane\) |  TCP  |  10250  |  Control plane security group  |  |
+| Recommended inbound traffic |  All TCP  |  All 1025\-65535  |  Worker node security group Control plane security group  |  |
+| Minimum outbound traffic |  TCP  |  443  |  |  Control plane security group  |
+| Recommended outbound traffic |  All  |  All  |  |  0\.0\.0\.0/0  |


### PR DESCRIPTION
*Issue #, if available:*
Page has an incorrect ephemeral port range for inbound access to control plane stated.

*Description of changes:*
Corrected the stated ephemeral port range for inbound access to control plane SG from the incorrect 66535 to correct 65535 (2^16-1). Hope it helps!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
