### PR TITLE
Changes in the private subnet consideration

### DIFF
--- a/doc_source/network_reqs.md
+++ b/doc_source/network_reqs.md
@@ -45,3 +45,6 @@ Private subnets in your VPC should be tagged accordingly so that Kubernetes know
 | Key | Value | 
 | --- | --- | 
 |  `kubernetes.io/role/internal-elb`  |  `1`  | 
+|  `kubernetes.io/cluster/<cluster-name>`  |  `shared`  | 
++ **Key**: The *<cluster\-name>* value matches your Amazon EKS cluster's name\. 
++ **Value**: The `shared` value allows more than one cluster to use this VPC\.


### PR DESCRIPTION
This is because for internal ELB auto subnet discovery, both tags are used -
kubernetes.io/role/internal-elb	1
kubernetes.io/cluster/<cluster-name>	shared

Since as per code, first kubernetes.io/cluster/<cluster-name> is checked and then kubernetes.io/role/internal-elb is checked.

If kubernetes.io/cluster/<cluster-name> is not mentioned, then internal ELB is created on Public Subnets.
https://github.com/kubernetes/kubernetes/issues/29298#issuecomment-356826381

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
