### PR TITLE
Correcting instructions to allow pods use secondary VPC CIDR

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -55,7 +55,7 @@ This feature requires [Amazon VPC CNI plugin for Kubernetes](https://github.com/
    1. Apply the file to your cluster with the following command:
 
       ```
-      kubectl apply -f ENIConfig.yaml
+      kubectl apply -f ENIConfig.yaml --validate=false
       ```
 
 1. Create an `ENIConfig` custom resource definition for each subnet in which your pods reside\.
@@ -83,8 +83,10 @@ Each subnet and security group combination requires its own custom resource defi
       kubectl apply -f group1-pod-netconfig.yaml
       ```
 
-1. For each node in your cluster, annotate the node with the custom network configuration to use\. Worker nodes can only be annotated with a single `ENIConfig` value at a time\. The subnet in the `ENIConfig` must belong to the same Availability Zone in which the worker node resides\.
+1. For each node in your cluster, annotate the node with the custom network configuration to use\. Worker nodes can only be annotated with a single `ENIConfig` value at a time\. The subnet in the `ENIConfig` must belong to the same Availability Zone in which the worker node resides\. 
+
+For example, when you run `kubectl get nodes` and get `ip-xx-x-xxx-xx.ec2.internal` as node name, you can run the following command to annotate the node with the custom network configuration.
 
    ```
-   kubectl annotate node <nodename>.<region>.compute.internal k8s.amazonaws.com/eniConfig=group1-pod-netconfig
+   kubectl annotate node ip-xx-x-xxx-xx.ec2.internal k8s.amazonaws.com/eniConfig=group1-pod-netconfig
    ```


### PR DESCRIPTION
Running what is mentioned in docs results in error as follows, 

kubectl apply -f ENIConfig.yaml
error: error validating "ENIConfig.yaml": error validating data: ValidationError(CustomResourceDefinition.spec.names): unknown field "scope" in io.k8s.apiextensions-apiserver.pkg.apis.apiextensions.v1beta1.CustomResourceDefinitionNames; if you choose to ignore these errors, turn validation off with --validate=false

Following works

kubectl apply -f ENIConfig.yaml --validate=false
customresourcedefinition.apiextensions.k8s.io "eniconfigs.crd.k8s.amazonaws.com" configured



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
