### PR TITLE
Changed ConfigMap to Daemonset

### DIFF
--- a/doc_source/external-snat.md
+++ b/doc_source/external-snat.md
@@ -13,7 +13,7 @@ SNAT is required for nodes that reside in a public subnet\. To use external SNAT
 
 **To disable SNAT on your worker nodes**
 
-1. Edit the `aws-node` configmap:
+1. Edit the `aws-node` daemonset:
 
    ```
    kubectl edit daemonset -n kube-system aws-node


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The environment variables for the CNI plugin are stored in the daemonset object, not a configmap. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: Jeremy Cowan <jicowan@hotmail.com>
