### PR TITLE
Fix log stream name of EKS control plane log

### DIFF
--- a/doc_source/control-plane-logs.md
+++ b/doc_source/control-plane-logs.md
@@ -114,5 +114,5 @@ As log stream data grows, the log stream names are rotated\. When multiple log s
    + **Kubernetes API server component logs \(`api`\)** – `kube-apiserver-nnn...`
    + **Audit \(`audit`\)** – `kube-apiserver-audit-nnn...`
    + **Authenticator \(`authenticator`\)** – `authenticator-nnn...`
-   + **Controller manager \(`controllerManager`\)** – `kube-apiserver-nnn...`
-   + **Scheduler \(`scheduler`\)** – `kube-apiserver-nnn...`
+   + **Controller manager \(`controllerManager`\)** – `kube-controller-manager-nnn...`
+   + **Scheduler \(`scheduler`\)** – `kube-scheduler-nnn...`


### PR DESCRIPTION
*Issue #, if available:*

No issue.

*Description of changes:*

Fix log stream name of EKS control plane log. In my environment, controller manager's (`controllerManager`) log stream starts with `kube-controller-manager-`, and scheduler's (`scheduler`) log stream starts with `kube-scheduler-`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
