### PR TITLE
PodPreset is not yet available on EKS

### DIFF
--- a/doc_source/iam-roles-for-service-accounts-technical-overview.md
+++ b/doc_source/iam-roles-for-service-accounts-technical-overview.md
@@ -74,7 +74,7 @@ AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/to
 ```
 
 **Note**  
-Your cluster does not need to use the mutating web hook to configure the environment variables and token file mounts; you can use a [PodPreset](https://kubernetes.io/docs/tasks/inject-data-application/podpreset/) to do this, or configure pods manually\.
+Your cluster does not need to use the mutating web hook to configure the environment variables and token file mounts; you can use a [PodPreset](https://kubernetes.io/docs/tasks/inject-data-application/podpreset/) to do this (Note, PodPreset is [not yet available](https://github.com/aws/containers-roadmap/issues/151) on EKS), or configure pods manually\.
 
 [Supported versions of the AWS SDK](iam-roles-for-service-accounts-minimum-sdk.md) look for these environment variables first in the credential chain provider\. The role credentials are used for pods that meet this criteria\.
 


### PR DESCRIPTION
To avoid confusion, I suggest to either adding a note (as this PR), or remove PodPreset from the context.

*Issue #, if available:*

*Description of changes:*
The doc was suggesting to use PodPreset as a workaround to configure the Pod as an alternative to the Pod Identity Webhook, however, PodPreset is not yet in Beta, and not enabled on EKS yet: https://github.com/aws/containers-roadmap/issues/151

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
