### PR TITLE
Add Pod Security Policy Note to Upgrade Guide

### DIFF
--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -25,6 +25,9 @@ Please update any 1\.10 clusters to version 1\.11 or higher in order to avoid se
 
 If you're using additional add\-ons for your cluster that aren't listed in the previous table, update them to the latest compatible versions after updating your cluster\.
 
+**Note**  
+The pod security policy admission controller is enabled on Amazon EKS clusters running Kubernetes version 1.13 or later. If you are upgrading the cluster from pre version 1.13, please ensure proper pod security policies are in place\. For more information, see [Amazon EKS Default Pod Security Policy](pod-security-policy.html#default-psp)\.
+
 Choose the tab below that corresponds to your desired cluster update method:
 
 ------


### PR DESCRIPTION
When customers are upgrading EKS cluster from pre 1.13 to 1.13 or later, and if they are following the guide: "https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html", they will run into the issues where pods (aws-node, coredns etc) can't be scheduled due to the missing proper pod security policies.

Adding this note to ensure customers are aware of this potential issue. If they don't have pod security policy in place, they could follow the guide on "https://docs.aws.amazon.com/eks/latest/userguide/pod-security-policy.html" to create a default eks.privileged policy for backwards compatibility.

*Issue #, if available:*

*Description of changes:*

Added a note paragraph to the update-cluster page to highlight the potential issues with pod security policy admission controller enabled since 1.13.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
