### PR TITLE
Address confusion due to some SDKs don't support this feature out of box

### DIFF
--- a/doc_source/iam-roles-for-service-accounts-minimum-sdk.md
+++ b/doc_source/iam-roles-for-service-accounts-minimum-sdk.md
@@ -13,6 +13,9 @@ The containers in your pods must use an AWS SDK version that supports assuming a
 + \.NET — [3\.3\.580\.0](https://github.com/aws/aws-sdk-net/releases/tag/3.3.580.0)
 + PHP — [3\.110\.7](https://github.com/aws/aws-sdk-php/releases/tag/3.110.7)
 
+**Note**  
+Depends on each SDK, this may not be enabled in the default credentials provider chain, in which case, spcifying web identity token credential provider in the client initialization. Refer to SDK documentation for more information.
+
 Note that many popular Kubernetes add\-ons, such the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) or the [ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller) will not work with this feature until they have been updated to use a supported version of their respective AWS SDKs\. The [Amazon VPC CNI plugin for Kubernetes](https://github.com/aws/amazon-vpc-cni-k8s) has been updated with a supported version of the AWS SDK for Go, and you can use the IAM roles for service accounts feature to provide the required permissions for the CNI to work\.
 
 To ensure that you are using a supported SDK, follow the installation instructions for your preferred SDK at [Tools for Amazon Web Services](https://aws.amazon.com/tools/) when you build your containers\. 


### PR DESCRIPTION
Customers got confuse and thought once they upgraded the SDK to the listed version or above, the web identity token would be used for exchanging AWS credentials without any code changes. However, it is not the case due to WebIdentityTokenFileCredentialsProvider is not in the default credential provider chain for certain SDKs, for example:

     Java SDK - https://github.com/aws/aws-sdk-java-v2/issues/1470
     DotNet SDK - https://github.com/aws/aws-sdk-net/issues/1413

*Issue #, if available:*

     Java SDK - https://github.com/aws/aws-sdk-java-v2/issues/1470
     DotNet SDK - https://github.com/aws/aws-sdk-net/issues/1413

*Description of changes:*

Added a note to at least tell customers code changes may be required to utilize this feature. I couldn't find better wording, so any comments or changes are welcome.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
