### PR TITLE
Add explanation for why Cluster Autoscaler should not be used in conj…

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -41,7 +41,7 @@ This cluster was created in the following Availability Zones: *us\-west\-2a us\-
 
 Create single\-zone node groups for each Availability Zone that your cluster was created in\. For more information, see [Launching Amazon EKS Linux Worker Nodes](launch-workers.md)\.
 
-The Cluster Autoscaler does not support Auto Scaling groups that span multiple Availability Zones\. Instead, use an Auto Scaling group for each Availability Zone\. You can later enable the `--balance-similar-node-groups` feature to keep your cluster's node count relatively even across Availability Zones\.
+The Cluster Autoscaler does not support Auto Scaling groups that span multiple Availability Zones\. Instead, use an Auto Scaling group for each Availability Zone\. You can later enable the `--balance-similar-node-groups` feature to keep your cluster's node count relatively even across Availability Zones\. If you do use a single Auto Scaling Group that spans multiple Availability Zones you will find that AWS unexpectedly terminates nodes without them being drained because of the [rebalancing feature of AWS EC2 Auto Scaling](https://docs.aws.amazon.com/autoscaling/ec2/userguide/auto-scaling-benefits.html#arch-AutoScalingMultiAZ).
 
 For each Availability Zone in your cluster, use the following `eksctl` command to create a node group\. Substitute the red variable text with your own values\. This command creates an Auto Scaling group with a minimum count of one and a maximum count of ten\.
 

--- a/doc_source/launch-workers.md
+++ b/doc_source/launch-workers.md
@@ -148,6 +148,15 @@ If you do not provide a keypair here, the AWS CloudFormation stack creation fail
       ```
 
    1. Open the file with your favorite text editor\. Replace the *<ARN of instance role \(not instance profile\)>* snippet with the **NodeInstanceRole** value that you recorded in the previous procedure, and save the file\.
+
+**Important**
+
+If you modified the template and changed the **Path** attribute of the **NodeInstanceRole** resource, then do not use the ARN as-is. Remove the path component from the ARN first.
+
+For e.g., if the **NodeInstanceRole** is `arn:aws:iam::111111111111:role/department/team/some-role-name`, then you should specify `arn:aws:iam::111111111111:role/some-role-name` below.
+
+You should also do this if you are adding additional roles to the config map (for e.g. adding a CodeBuild project's role so it can deploy pods to your cluster).
+
 **Important**  
 Do not modify any other lines in this file\.
 


### PR DESCRIPTION
…unction with a single multi-Z ASG.

This is pertinent because some people may have previously encountered [eksworkshop.com](https://eksworkshop.com/scaling/deploy_ca/) docco for Cluster AutoScaler which uses just one multi-AZ ASG, and may be curious about which advice is correct and why.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
