### PR TITLE
Added one more reason to Worker Nodes Fail to Join Cluster

### DIFF
--- a/doc_source/troubleshooting.md
+++ b/doc_source/troubleshooting.md
@@ -16,9 +16,11 @@ If you receive the error `"aws-iam-authenticator": executable file not found in 
 
 ## Worker Nodes Fail to Join Cluster<a name="worker-node-fail"></a>
 
-There are two common reasons that prevent worker nodes from joining the cluster:
+There are thre common reasons that prevent worker nodes from joining the cluster:
 + The `aws-auth-cm.yaml` file does not have the correct IAM role ARN for your worker nodes\. Ensure that the worker node IAM role ARN \(not the instance profile ARN\) is specified in your `aws-auth-cm.yaml` file\. For more information, see [Launching Amazon EKS Linux Worker Nodes](launch-workers.md)\.
 + The **ClusterName** in your worker node AWS CloudFormation template does not exactly match the name of the cluster you want your worker nodes to join\. Passing an incorrect value to this field results in an incorrect configuration of the worker node's `/var/lib/kubelet/kubeconfig` file, and the nodes will not join the cluster\.
+
++ Node must be "owned" by the cluster. Check if the EC2 instance has tag kubernetes.io/cluster/[cluster_name]:ownned
 
 ## Unauthorized or Access Denied \(`kubectl`\)<a name="unauthorized"></a>
 


### PR DESCRIPTION
If the Node is not owned by cluster, Node will fail to join the cluster. Adding this step here will help newbies.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
