### PR TITLE
Add STS regional endpoint

### DIFF
--- a/doc_source/iam-roles-for-service-accounts-technical-overview.md
+++ b/doc_source/iam-roles-for-service-accounts-technical-overview.md
@@ -182,3 +182,27 @@ web_identity_token_file = /var/run/secrets/eks.amazonaws.com/serviceaccount/toke
 role_arn=arn:aws:iam::111111111111:role/account-a-role
 ```
 To specify chained profiles for other AWS SDKs, consult their documentation\.
+
+## STS Regional Endpoint<a name="sts-regional-endpoint"></a>
+
+By default IAM Roles for Service Accounts work with global STS endpoint `sts.amazonaws.com`\. You can configure it to work with regional STS endpoint\. Steps required are listed below with `eu-west-2` STS endpoint as an example\.
+
+**Update audience in OIDC Token**  
+
+The audience in OIDC token can be customized via annotations of the Kubernetes ServiceAccount resource\. 
+
+```
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  annotations:
+    eks.amazonaws.com/audience: sts.eu-west-2.amazonaws.com
+```
+
+**Update audience in IAM OIDC Provider**
+
+The OIDC provider configured in IAM needs to have STS regional endpoint listed as one of the audiences\. Navigate to **IAM**, **Identity providers**, open the provider for your EKS cluster, and add `sts.eu-west-2.amazonaws.com` as an audience\.
+
+**Update audience in IAM Role Trust Relationships**
+
+The audience may be listed as one of the conditions (condition key ending with **:aud**) in the IAM Role created for Kubernetes Service Account\. If it is listed, make sure the value of the condition is updated to match the STS regional endpoint\.


### PR DESCRIPTION
IAM Role for Service Account supports STS regional endpoint, but it is not documented. This is to add documentation of how to configure it to work with STS regional endpoint.

*Description of changes:*

As shown here (https://github.com/aws/amazon-eks-pod-identity-webhook/blob/2fd4becd434f92edab01cecee30ea4b12af93ab7/hack/example-app.yaml), and tested by myself, IAM Role for Service Account can work with regional STS endpoint. This suits some customers who don't want to use global STS endpoint. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
