### PR TITLE
Add instructions to tag public subnets

### DIFF
--- a/doc_source/getting-started-console.md
+++ b/doc_source/getting-started-console.md
@@ -125,6 +125,19 @@ Choose the tab below that represents your desired VPC configuration\.
 [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/eks/latest/userguide/getting-started-console.html)
 
    1. Repeat these substeps for each private subnet in your VPC\.
+   
+1. Tag your public subnets so that Kubernetes knows that it can use them for public load balancers\.
+
+   1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/)\.
+
+   1. Choose **Subnets** in the left navigation\.
+
+   1. Select one of the public subnets for your Amazon EKS cluster's VPC \(you can filter them with the string `PublicSubnet`\), and choose the **Tags** tab, and then **Add/Edit Tags**\.
+
+   1. Choose **Create Tag** and add the following key and value, and then choose **Save**\.    
+[\[See the AWS documentation website for more details\]](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
+
+   1. Repeat these substeps for each public subnet in your VPC\.
 
 ------
 


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
Hello, there is a section missing on tagging the public subnets so that Kubernetes can use the ALBs to create public services. It is documented [here](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html) but it is missing from the getting started guide.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
