### PR TITLE
Add Tagging Requirement for Worker Node Security Group

### DIFF
--- a/doc_source/load-balancing.md
+++ b/doc_source/load-balancing.md
@@ -33,3 +33,15 @@ Private subnets in your VPC should be tagged accordingly so that Kubernetes know
 | Key | Value | 
 | --- | --- | 
 |  `kubernetes.io/role/internal-elb`  |  `1`  | 
+
+## Worker Node Security Group Tagging for Load Balancers<a name="worker-node-security-group-tagging-for-load-balancers"></a>
+
+Worker node security group may be tagged accordingly so that Kubernetes knows which security group to add or remove ingress rule for load balancer security group:
+
++ The tag on security group is optional if you only have one security group on your worker node (primary ENI)\.
++ The tag is required on exactly one security group if you have multiple security groups on your worker node (primary ENI)\.
+
+| Key | Value | 
+| --- | --- | 
+|  `kubernetes.io/cluster/<cluster-name>`  |  `owned`  | 
++ **Key**: The *<cluster\-name>* value matches your Amazon EKS cluster's name\. 


### PR DESCRIPTION
As per reported issue on here: kubernetes/kubernetes#84287

Moved this doc change to Load Balancing page as per https://github.com/awsdocs/amazon-eks-user-guide/pull/63

Worker node security group requires a cluster tag so Cloud Controller Manager knows which security group to add or remove the ingress rules. Otherwise, it will cause load balancer security group failed to get removed.

If there is only one security group on the worker node, the tag is optional. The tag is only required on exactly one security group if there are multiple security groups on the worker node.

Issue #, if available:
84287

Description of changes:
Add worker node security group tagging requirement.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.