### PR TITLE
Cni 1.6.0

### DIFF
--- a/doc_source/cni-upgrades.md
+++ b/doc_source/cni-upgrades.md
@@ -2,7 +2,7 @@
 
 When you launch an Amazon EKS cluster, we apply a recent version of the [Amazon VPC CNI plugin for Kubernetes](https://github.com/aws/amazon-vpc-cni-k8s) to your cluster \(the absolute latest version of the plugin is available [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases) for a short grace period before new clusters are switched over to use it\)\. However, Amazon EKS does not automatically upgrade the CNI plugin on your cluster when new versions are released\. You must upgrade the CNI plugin manually to get the latest version on existing clusters\.
 
-The latest recommended CNI version available [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases) is 1\.5\.5\. You can view the different releases available for the plugin, and read the release notes for each version [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases)\.
+The latest recommended CNI version available [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases) is 1\.6\.0\. You can view the different releases available for the plugin, and read the release notes for each version [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases)\.
 
 Use the following procedures to check your CNI version and upgrade to the latest recommended version\.
 

--- a/doc_source/cni-upgrades.md
+++ b/doc_source/cni-upgrades.md
@@ -16,14 +16,14 @@ Use the following procedures to check your CNI version and upgrade to the latest
   Output:
 
   ```
-  amazon-k8s-cni:1.5.3
+  amazon-k8s-cni:1.5.5
   ```
 
-  In this example output, the CNI version is 1\.5\.3, which is earlier than the current recommended version, 1\.5\.5\. Use the following procedure to upgrade the CNI\.
+  In this example output, the CNI version is 1\.5\.5, which is earlier than the current recommended version, 1\.6\.0\. Use the following procedure to upgrade the CNI\.
 
 **To upgrade the Amazon VPC CNI Plugin for Kubernetes**
 + Use the following command to upgrade your CNI version to the latest recommended version:
 
   ```
-  kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/aws-k8s-cni.yaml
+  kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/aws-k8s-cni.yaml
   ```

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -14,7 +14,7 @@ Amazon EKS does not modify any of your Kubernetes add\-ons when you update a clu
 
 | Kubernetes Version | 1\.14 | 1\.13 | 1\.12 | 
 | --- | --- | --- | --- | 
-| Amazon VPC CNI plug\-in | 1\.5\.5 | 1\.5\.5 | 1\.5\.5 | 
+| Amazon VPC CNI plug\-in | 1\.6\.0 | 1\.6\.0 | 1\.6\.0 | 
 | DNS \(CoreDNS\) | 1\.6\.6 | 1\.6\.6 | 1\.6\.6 | 
 | KubeProxy | 1\.14\.9 | 1\.13\.12 | 1\.12\.10 | 
 
@@ -232,13 +232,13 @@ The cluster update should finish in a few minutes\.
    Output:
 
    ```
-   amazon-k8s-cni:1.5.3
+   amazon-k8s-cni:1.5.5
    ```
 
-   If your CNI version is earlier than 1\.5\.5, use the following command to update your CNI version to the latest recommended version:
+   If your CNI version is earlier than 1\.6\.0, use the following command to update your CNI version to the latest recommended version:
 
    ```
-   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.5/config/v1.5/aws-k8s-cni.yaml
+   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/aws-k8s-cni.yaml
    ```
 
 1. \(Clusters with GPU workers only\) If your cluster has worker node groups with GPU support \(for example, `p3.2xlarge`\), you must update the [NVIDIA device plugin for Kubernetes](https://github.com/NVIDIA/k8s-device-plugin) DaemonSet on your cluster with the following command\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
CNI plugin is now at 1.6.0. Upgrade documentation needs to change the kubectl apply command to reflect the new branch, as well as updating the verbiage to reflect the latest version

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
