### PR TITLE
Update urls to download eksctl binaries

### DIFF
--- a/doc_source/eksctl.md
+++ b/doc_source/eksctl.md
@@ -59,7 +59,7 @@ The `GitTag` version should be at least `0.11.1`\. If not, check your terminal o
 1. Download and extract the latest release of `eksctl` with the following command\.
 
    ```
-   curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+   curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
    ```
 
 1. Move the extracted binary to `/usr/local/bin`\.

--- a/doc_source/getting-started-eksctl.md
+++ b/doc_source/getting-started-eksctl.md
@@ -95,7 +95,7 @@ The `GitTag` version should be at least `0.11.1`\. If not, check your terminal o
 1. Download and extract the latest release of `eksctl` with the following command\.
 
    ```
-   curl --silent --location "https://github.com/weaveworks/eksctl/releases/download/latest_release/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
+   curl --silent --location "https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_$(uname -s)_amd64.tar.gz" | tar xz -C /tmp
    ```
 
 1. Move the extracted binary to `/usr/local/bin`\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Eksctl is deprecating the `latest_release` tag. To download the binary
for the latest release these Github urls should be used instead:

https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Linux_amd64.tar.gz
https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Darwin_amd64.tar.gz
https://github.com/weaveworks/eksctl/releases/latest/download/eksctl_Windows_amd64.zip


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.