### PR TITLE
Clarify custom networks for multi-AZ node groups

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -49,7 +49,7 @@ Enabling a custom network effectively removes an available elastic network inter
 
 1. Create an `ENIConfig` custom resource for each subnet that you want to schedule pods in\.
 
-   1. Create a unique file for each elastic network interface configuration\. Each file must include the contents below with a unique value for `name`\. In this example, a file named `region-codea.yaml` is created\. Replace the *example values* for `name`, `subnet`, and `securityGroups` with your own values\. In this example, the value for `name` is the same as the Availability Zone that the subnet is in\. If you don't have a specific security group that you want to attach for your pods, you can leave that value empty for now\. Later, you will specify the worker node security group in the `ENIConfig`\.
+   1. Create a unique file for each elastic network interface configuration\. Each file must include the contents below with a unique value for `name`\. We highly recommend using a `name` that matches the Availability Zone of the subnet, as this makes deployment of multi-AZ AutoScalingGroups simpler (see below in 5c)\. In this example, a file named `us-west-2.yaml` is created\. Replace the *example values* for `name`, `subnet`, and `securityGroups` with your own values\. In this example, we follow best practices and set the value for `name` to the Availability Zone that the subnet is in\. If you don't have a specific security group that you want to attach for your pods, you can leave that value empty for now\. Later, you will specify the worker node security group in the `ENIConfig`\.
 **Note**  
 Each subnet and security group combination requires its own custom resource\.
 
@@ -57,7 +57,7 @@ Each subnet and security group combination requires its own custom resource\.
       apiVersion: crd.k8s.amazonaws.com/v1alpha1
       kind: ENIConfig
       metadata: 
-        name: region-codea
+        name: us-west-2
       spec: 
         securityGroups: 
           - sg-0dff111a1d11c1c11
@@ -67,10 +67,10 @@ Each subnet and security group combination requires its own custom resource\.
    1. Apply each custom resource file that you created to your cluster with the following command:
 
       ```
-      kubectl apply -f region-codea.yaml
+      kubectl apply -f us-west-2.yaml
       ```
 
-   1. \(Optional\) By default, Kubernetes applies the Availability Zone of a node to the `k8s.amazonaws.com/eniConfig` label\. If you named your ENIConfig custom resources after each Availability Zone in your VPC, then you can enable Kubernetes to automatically apply the ENIConfig for each Availability Zone to the worker node in the same Availability Zone with the following command\.
+   1. \(Optional, but recommended for multi-AZ worker node groups\) By default, Kubernetes applies the Availability Zone of a node to the `k8s.amazonaws.com/eniConfig` label\. If you named your ENIConfig custom resources after each Availability Zone in your VPC, as recommended in step 5a above, then you can enable Kubernetes to automatically apply the corresponding ENIConfig for the worker node's Availability Zone with the following command\.
 
       ```
       kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone
@@ -95,14 +95,16 @@ Ensure that an annotation with the key `k8s.amazonaws.com/eniConfig` for the `EN
       For more information about the the maximum number of network interfaces per instance type, see [Elastic Network Interfaces](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) in the Amazon EC2 User Guide for Linux Instances\.
 
    1. Follow the steps in the **Self\-managed nodes** tab of [Launching Amazon EKS Linux Worker Nodes](launch-workers.md) to create each new self\-managed worker node group\. After you've opened the AWS CloudFormation template, enter values as described in the instructions\. For the following fields however, ensure that you enter or select the listed values\.
-      + **BootstrapArguments**: – Enter `--use-max-pods false --kubelet-extra-args '--node-labels=k8s.amazonaws.com/eniConfig=region-codea --max-pods=20'`
+      + **BootstrapArguments**: – Enter `--use-max-pods false --kubelet-extra-args '--max-pods=20'`
       + **Subnets**: – Choose the subnet that you created specifically for this worker node group in step 2\.
 
-1. After your worker node groups are created, record the security group that was created for each worker node group and apply it to its associated `ENIConfig`\. Edit each `ENIConfig` with the following command, replacing *region\-codea* with your value:
+1. After your worker node groups are created, record the security group that was created for each worker node group and apply it to its associated `ENIConfig`\. Edit each `ENIConfig` with the following command, replacing *eniconfig-name* with your value:
 
    ```
-   kubectl edit eniconfig.crd.k8s.amazonaws.com/region-codea
+   kubectl edit eniconfig.crd.k8s.amazonaws.com/eniconfig-name
    ```
+**Note**  
+If you followed best practices from 5a and 5c above, the *eniconfig-name* would correspond to the Availability Zone name.
 
    The `spec` section should look like this:
 


### PR DESCRIPTION
There was some confusion when following the instructions for setting up
custom network configuration for multiple Availability Zones. The previous
documentation included instructions to use the `--node-labels` bootstrap
argument when creating a new worker node group, and specified the AZ
name as a node label. This doesn't work, however, when the user wants to
have a worker node group in multiple AZs. Instead, the availability zone of
the node is already added in the `failure-domain.beta.kubernetes.io/zone`
label.

We clarify these instructions by removing the `--node-labels` part of the bootstrap
args in the step which creates a worker node group and add some notes to step
5a and 5c that indicate recommended practice is to set the ENIConfig's `name`
field to that of the Availability Zone and then simply issue the call to:

```
kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone
```

which will be appropriate even for worker node groups in multiple AZs.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
