### PR TITLE
Set ENIConfig.name to AZ correctly

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -49,7 +49,7 @@ Enabling a custom network effectively removes an available elastic network inter
 
 1. Create an `ENIConfig` custom resource for each subnet that you want to schedule pods in\.
 
-   1. Create a unique file for each elastic network interface configuration\. Each file must include the contents below with a unique value for `name`\. We highly recommend using a value for `name` that matches the Availability Zone of the subnet, as this makes deployment of multi\-AZ Auto Scaling groups simpler \(see step 5c below\)\. In this example, a file named `us-west-2.yaml` is created\. Replace the *example values* for `name`, `subnet`, and `securityGroups` with your own values\. In this example, we follow best practices and set the value for `name` to the Availability Zone that the subnet is in\. If you don't have a specific security group that you want to attach for your pods, you can leave that value empty for now\. Later, you will specify the worker node security group in the ENIConfig\.
+   1. Create a unique file for each elastic network interface configuration\. Each file must include the contents below with a unique value for `name`\. We highly recommend using a value for `name` that matches the Availability Zone of the subnet, as this makes deployment of multi\-AZ Auto Scaling groups simpler \(see step 5c below\)\. In this example, a file named `us-west-2a.yaml` is created\. Replace the *example values* for `name`, `subnet`, and `securityGroups` with your own values\. In this example, we follow best practices and set the value for `name` to the Availability Zone that the subnet is in\. If you don't have a specific security group that you want to attach for your pods, you can leave that value empty for now\. Later, you will specify the worker node security group in the ENIConfig\.
 **Note**  
 Each subnet and security group combination requires its own custom resource\.
 
@@ -57,7 +57,7 @@ Each subnet and security group combination requires its own custom resource\.
       apiVersion: crd.k8s.amazonaws.com/v1alpha1
       kind: ENIConfig
       metadata: 
-        name: us-west-2
+        name: us-west-2a
       spec: 
         securityGroups: 
           - sg-0dff111a1d11c1c11
@@ -67,7 +67,7 @@ Each subnet and security group combination requires its own custom resource\.
    1. Apply each custom resource file that you created to your cluster with the following command:
 
       ```
-      kubectl apply -f us-west-2.yaml
+      kubectl apply -f us-west-2a.yaml
       ```
 
    1. \(Optional, but recommended for multi\-AZ worker node groups\) By default, Kubernetes applies the Availability Zone of a node to the `k8s.amazonaws.com/eniConfig` label\. If you named your ENIConfig custom resources after each Availability Zone in your VPC, as recommended in step 5a above, then you can enable Kubernetes to automatically apply the corresponding ENIConfig for the worker node's Availability Zone with the following command\.


### PR DESCRIPTION
Forgot to add the "a" to signal the AZ. Thanks to @jolcese for catching this mistake!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
