### PR TITLE
Update 'eksctl create nodegroup' command in migrate-stack guide

### DIFF
--- a/doc_source/migrate-stack.md
+++ b/doc_source/migrate-stack.md
@@ -37,8 +37,8 @@ For more available flags and their descriptions, see [https://eksctl\.io/](https
    ```
    eksctl create nodegroup \
    --cluster default \
-   --version 1.14 \
-   --name standard-1-1.14 \
+   --version 1.15 \
+   --name standard-1-15 \
    --node-type t3.medium \
    --nodes 3 \
    --nodes-min 1 \


### PR DESCRIPTION
Two small changes to the `eksctl create nodegroup` command in the docs:

- Use the most recent Kubernetes version, 1.15
- Update `name` to exclude characters that fail the 'stackName' validation constraint

The `name` argument must not contain '.' otherwise it will fail validation and receive the error:

> ValidationError: 1 validation error detected: Value 'eksctl-my-cluster-nodegroup-workers-1.15' at 'stackName' failed to satisfy constraint: Member must satisfy regular expression pattern: [a-zA-Z][-a-zA-Z0-9]*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
