### PR TITLE
Updating documentation to read "EKS Cluster" instead of EKS

### DIFF
--- a/doc_source/service_IAM_role.md
+++ b/doc_source/service_IAM_role.md
@@ -54,7 +54,7 @@ You can use the AWS Management Console or AWS CloudFormation to create the clust
 
 1. Choose **Roles**, then **Create role**\.
 
-1. Choose **EKS** from the list of services, then **EKS** for your use case, and then **Next: Permissions**\.
+1. Choose **EKS** from the list of services, then **EKS - Cluster** for your use case, and then **Next: Permissions**\.
 
 1. Choose **Next: Tags**\.
 


### PR DESCRIPTION
If you following these directions directly they will result in a EKS role that cannot setup the necessary services.  The user should select EKS Cluster and not EKS as the use case.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
