### PR TITLE
updated cni-env-var doc to reflect correct log levels

### DIFF
--- a/doc_source/cni-env-vars.md
+++ b/doc_source/cni-env-vars.md
@@ -75,7 +75,7 @@ Specifies the maximum number of ENIs that will be attached to the node\. When `M
 **`AWS_VPC_K8S_CNI_LOGLEVEL`**  
 **Type** – String  
 **Default** – DEBUG  
-**Valid values** – `trace`, `debug`, `info`, `warn`, `error`, `critical`, or `off` \(not case sensitive\)  
+**Valid values** – `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL` \(not case sensitive\)  
 Specifies the loglevel for `ipamd`\.
 
 **`AWS_VPC_K8S_CNI_LOG_FILE`**  
@@ -92,7 +92,8 @@ Specifies where to write the logging output for the `aws-cni` plugin\. You can s
 
 **`AWS_VPC_K8S_PLUGIN_LOG_LEVEL`**  
 **Type** – String  
-**Valid values** – `trace`, `debug`, `info`, `warn`, `error`, `critical`, or `off` \(not case sensitive\)  
+**Default** – DEBUG
+**Valid values** – `DEBUG`, `INFO`, `WARN`, `ERROR`, `FATAL` \(not case sensitive\)  
 Specifies the log level for the `aws-cni` plugin\.
 
 **`INTROSPECTION_BIND_ADDRESS`**  


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Updated cni-env-var doc to reflect correct log levels. Follow to https://github.com/aws/amazon-vpc-cni-k8s/pull/958


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
