### PR TITLE
Fixed update cluster doc for kube-proxy

### DIFF
--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -180,16 +180,19 @@ The cluster update should finish in a few minutes\.
 
 ------
 
-Update `kube-proxy` on Worker nodes:
-- Check existing `kube-proxy` DaemonSet configuration on the cluster,
+Update `kube-proxy` on Cluster:
+- `kube-proxy --resource-containers` flag has been deprecated in [Kubernetes 1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals). If your cluster was created and upgraded since EKS 1.11, your kube-proxy DaemonSet spec does not use configMap to pull configuration and has `--resource-containers` flag. This fails in Kubernetes 1.16, and must be removed before upgrading to EKS 1.16.
+- **Note**:
+  - EKS 1.12 and later already creates "kube-proxy-config" during cluster creation. This is only needed for EKS 1.10 and 1.11 clusters that being upgraded to EKS 1.16.
+- Check `kube-proxy` configuration on the cluster for `--resource-containers` flag by running below command,
    ```
-   kubectl get ds kube-proxy -n kube-system -o jsonpath={.spec.template.spec.containers[0].command}
+   kubectl get daemonset kube-proxy --namespace kube-system -o jsonpath={.spec.template.spec.containers[0].command}
    ```
-   1. If above command returns below output,
+   1. If above command returns output with config path to a file,
       ```
       [kube-proxy --v=2 --config=/var/lib/kube-proxy-config/config]
       ``` 
-      - Patch the `kube-proxy` daemonset to use the image that corresponds to your cluster's Region and current Kubernetes version \(in this example, `1.16.8`\)\.    
+      - then patch `kube-proxy` DaemonSet to use the image that corresponds to your cluster's Region and current Kubernetes version \(in this example, `1.16.8`\)\.    
       [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html)
 
          - First, retrieve your current `kube-proxy` image:
@@ -207,7 +210,7 @@ Update `kube-proxy` on Worker nodes:
             ```
 
             Your account ID and region may differ from the example above\.
-   2. If above command returns output with `--random-fully` in it. A new manifest should be applied for `kube-proxy` on your cluster.
+   2. If above command returns output with `--random-fully` flag. A new manifest should be applied for `kube-proxy` on your cluster. Below are steps,
       1. Replace placeholders for  **REGION** and **MASTER_ENDPOINT** in below manifest.
          1. **REGION**: with EKS cluster region. Example: `us-east-1`
          2. **MASTER_ENDPOINT**: with EKS cluster api-server endpoint. It should look similar to this, `https://FGHJ474NNDJFKFKNGJGJGKN44.sk1.us-east-1.eks.amazonaws.com`

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -226,146 +226,146 @@ Update `kube-proxy` on Cluster:
          apiVersion: v1
          kind: ConfigMap
          metadata:
-         name: kube-proxy
-         namespace: kube-system
-         labels:
-            k8s-app: kube-proxy
-            eks.amazonaws.com/component: kube-proxy
+           name: kube-proxy
+           namespace: kube-system
+           labels:
+             k8s-app: kube-proxy
+             eks.amazonaws.com/component: kube-proxy
          data:
-         kubeconfig: |-
-            kind: Config
-            apiVersion: v1
-            clusters:
-            - cluster:
-               certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-               server: MASTER_ENDPOINT
+           kubeconfig: |-
+             kind: Config
+             apiVersion: v1
+             clusters:
+             - cluster:
+                 certificate-authority: /var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+                 server: MASTER_ENDPOINT
                name: default
-            contexts:
-            - context:
-               cluster: default
-               namespace: default
-               user: default
+             contexts:
+             - context:
+                 cluster: default
+                 namespace: default
+                 user: default
                name: default
-            current-context: default
-            users:
-            - name: default
+             current-context: default
+             users:
+             - name: default
                user:
-               tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
-
+                 tokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+         
          ---
          apiVersion: v1
          kind: ConfigMap
          metadata:
-         name: kube-proxy-config
-         namespace: kube-system
-         labels:
-            k8s-app: kube-proxy
-            eks.amazonaws.com/component: kube-proxy
+           name: kube-proxy-config
+           namespace: kube-system
+           labels:
+             k8s-app: kube-proxy
+             eks.amazonaws.com/component: kube-proxy
          data:
-         config: |-
-            apiVersion: kubeproxy.config.k8s.io/v1alpha1
-            bindAddress: 0.0.0.0
-            clientConnection:
+           config: |-
+             apiVersion: kubeproxy.config.k8s.io/v1alpha1
+             bindAddress: 0.0.0.0
+             clientConnection:
                acceptContentTypes: ""
                burst: 10
                contentType: application/vnd.kubernetes.protobuf
                kubeconfig: /var/lib/kube-proxy/kubeconfig
                qps: 5
-            clusterCIDR: ""
-            configSyncPeriod: 15m0s
-            conntrack:
+             clusterCIDR: ""
+             configSyncPeriod: 15m0s
+             conntrack:
                max: 0
                maxPerCore: 32768
                min: 131072
                tcpCloseWaitTimeout: 1h0m0s
                tcpEstablishedTimeout: 24h0m0s
-            enableProfiling: false
-            healthzBindAddress: 0.0.0.0:10256
-            hostnameOverride: ""
-            iptables:
+             enableProfiling: false
+             healthzBindAddress: 0.0.0.0:10256
+             hostnameOverride: ""
+             iptables:
                masqueradeAll: false
                masqueradeBit: 14
                minSyncPeriod: 0s
                syncPeriod: 30s
-            ipvs:
+             ipvs:
                excludeCIDRs: null
                minSyncPeriod: 0s
                scheduler: ""
                syncPeriod: 30s
-            kind: KubeProxyConfiguration
-            metricsBindAddress: 127.0.0.1:10249
-            mode: "iptables"
-            nodePortAddresses: null
-            oomScoreAdj: -998
-            portRange: ""
-            udpIdleTimeout: 250ms
-
+             kind: KubeProxyConfiguration
+             metricsBindAddress: 127.0.0.1:10249
+             mode: "iptables"
+             nodePortAddresses: null
+             oomScoreAdj: -998
+             portRange: ""
+             udpIdleTimeout: 250ms
+         
          ---
          apiVersion: v1
          kind: ServiceAccount
          metadata:
-         name: kube-proxy
-         namespace: kube-system
-         labels:
-            k8s-app: kube-proxy
-            eks.amazonaws.com/component: kube-proxy
+           name: kube-proxy
+           namespace: kube-system
+           labels:
+             k8s-app: kube-proxy
+             eks.amazonaws.com/component: kube-proxy
 
          ---
          kind: ClusterRoleBinding
          apiVersion: rbac.authorization.k8s.io/v1
          metadata:
-         name: eks:kube-proxy
-         labels:
-            k8s-app: kube-proxy
-            eks.amazonaws.com/component: kube-proxy
+           name: eks:kube-proxy
+           labels:
+             k8s-app: kube-proxy
+             eks.amazonaws.com/component: kube-proxy
          subjects:
-         - kind: ServiceAccount
-            name: kube-proxy
-            namespace: kube-system
+           - kind: ServiceAccount
+             name: kube-proxy
+             namespace: kube-system
          roleRef:
-         kind: ClusterRole
-         name: system:node-proxier
-         apiGroup: rbac.authorization.k8s.io
-
+           kind: ClusterRole
+           name: system:node-proxier
+           apiGroup: rbac.authorization.k8s.io
+                  
          ---
          apiVersion: apps/v1
          kind: DaemonSet
          metadata:
-         labels:
-            k8s-app: kube-proxy
-            eks.amazonaws.com/component: kube-proxy
-         name: kube-proxy
-         namespace: kube-system
+           labels:
+             k8s-app: kube-proxy
+             eks.amazonaws.com/component: kube-proxy
+           name: kube-proxy
+           namespace: kube-system
          spec:
-         selector:
-            matchLabels:
+           selector:
+             matchLabels:
                k8s-app: kube-proxy
-         updateStrategy:
-            type: RollingUpdate
-            rollingUpdate:
+           updateStrategy:
+             type: RollingUpdate
+             rollingUpdate:
                maxUnavailable: 10%
-         template:
-            metadata:
+           template:
+             metadata:
                labels:
-               k8s-app: kube-proxy
-            spec:
+                 k8s-app: kube-proxy
+             spec:
                affinity:
-               nodeAffinity:
-                  requiredDuringSchedulingIgnoredDuringExecution:
+                 nodeAffinity:
+                   requiredDuringSchedulingIgnoredDuringExecution:
                      nodeSelectorTerms:
                      - matchExpressions:
-                     - key: "kubernetes.io/os"
-                        operator: In
-                        values:
-                        - linux
-                     - key: "kubernetes.io/arch"
-                        operator: In
-                        values:
-                        - amd64
-                     # Not launching daemonset pods to fargate nodes
-                     - key: "eks.amazonaws.com/compute-type"
-                        operator: NotIn
-                        values:
+                       - key: "kubernetes.io/os"
+                         operator: In
+                         values:
+                         - linux
+                       - key: "kubernetes.io/arch"
+                         operator: In
+                         values:
+                         - amd64
+                       # Not launching daemonset pods to fargate nodes
+                       - key: "eks.amazonaws.com/compute-type"
+                         operator: NotIn
+                         values:
                            - fargate
                hostNetwork: true
                tolerations:
@@ -373,48 +373,49 @@ Update `kube-proxy` on Cluster:
                priorityClassName: system-node-critical
                containers:
                - name: kube-proxy
-               image: 602401143452.dkr.ecr.REGION.amazonaws.com/eks/kube-proxy:v1.16.8
-               resources:
-                  requests:
+                 image: 602401143452.dkr.ecr.REGION.amazonaws.com/eks/kube-proxy:v1.16.8
+                 resources:
+                   requests:
                      cpu: 100m
-               command:
-               - kube-proxy
-               - --v=2
-               - --config=/var/lib/kube-proxy-config/config
-               securityContext:
-                  privileged: true
-               volumeMounts:
-               - mountPath: /var/log
-                  name: varlog
-                  readOnly: false
-               - mountPath: /run/xtables.lock
-                  name: xtables-lock
-                  readOnly: false
-               - mountPath: /lib/modules
-                  name: lib-modules
-                  readOnly: true
-               - name: kubeconfig
-                  mountPath: /var/lib/kube-proxy/
-               - name: config
-                  mountPath: /var/lib/kube-proxy-config/
+                 command:
+                 - kube-proxy
+                 - --v=2
+                 - --config=/var/lib/kube-proxy-config/config
+                 securityContext:
+                   privileged: true
+                 volumeMounts:
+                 - mountPath: /var/log
+                   name: varlog
+                   readOnly: false
+                 - mountPath: /run/xtables.lock
+                   name: xtables-lock
+                   readOnly: false
+                 - mountPath: /lib/modules
+                   name: lib-modules
+                   readOnly: true
+                 - name: kubeconfig
+                   mountPath: /var/lib/kube-proxy/
+                 - name: config
+                   mountPath: /var/lib/kube-proxy-config/
                volumes:
                - name: varlog
-               hostPath:
-                  path: /var/log
+                 hostPath:
+                   path: /var/log
                - name: xtables-lock
-               hostPath:
-                  path: /run/xtables.lock
-                  type: FileOrCreate
+                 hostPath:
+                   path: /run/xtables.lock
+                   type: FileOrCreate
                - name: lib-modules
-               hostPath:
-                  path: /lib/modules
+                 hostPath:
+                   path: /lib/modules
                - name: kubeconfig
-               configMap:
-                  name: kube-proxy
+                 configMap:
+                   name: kube-proxy
                - name: config
-               configMap:
-                  name: kube-proxy-config
+                 configMap:
+                   name: kube-proxy-config
                serviceAccountName: kube-proxy
+
          ```
       3. Run command,
          ```

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -207,10 +207,14 @@ Update `kube-proxy` on Worker nodes:
             ```
 
             Your account ID and region may differ from the example above\.
-   2. If above command returns output with `--random-fully` in it. This option is not supported for `kube-proxy` 1.16 version. Hence, update kube-proxy manifest on your cluster.
+   2. If above command returns output with `--random-fully` in it. A new manifest should be applied for `kube-proxy` on your cluster.
       1. Replace placeholders for  **REGION** and **MASTER_ENDPOINT** in below manifest.
          1. **REGION**: with EKS cluster region. Example: `us-east-1`
-         2. **MASTER_ENDPOINT**: with EKS cluster api-server endpoint. It looks similar to this, `https://FGHJ474NNDJFKFKNGJGJGKN44.sk1.us-east-1.eks.amazonaws.com`
+         2. **MASTER_ENDPOINT**: with EKS cluster api-server endpoint. It should look similar to this, `https://FGHJ474NNDJFKFKNGJGJGKN44.sk1.us-east-1.eks.amazonaws.com`
+            1. You could also get eks api server endpoint using following command,
+               ```
+               aws eks describe-cluster --name <EKS_CLUSTER_NAME> --region <EKS_CLUSTER_REGION> --query 'cluster.endpoint' --output text
+               ```
       
       2. Save below content to `kube-proxy-1-16.yml` on your computer,
          ```

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -181,7 +181,8 @@ The cluster update should finish in a few minutes\.
 ------
 
 Update `kube-proxy` on Cluster:
-- `kube-proxy --resource-containers` flag has been deprecated in [Kubernetes 1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals). If your cluster was created and upgraded since EKS 1.11, your kube-proxy DaemonSet spec does not use configMap to pull configuration and has `--resource-containers` flag. This fails in Kubernetes 1.16, and must be removed before upgrading to EKS 1.16.
+
+`kube-proxy --resource-containers` flag has been deprecated in [Kubernetes 1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals). If your cluster was created and upgraded since EKS 1.11, your kube-proxy DaemonSet spec does not use configMap to pull configuration and has `--resource-containers` flag. This fails in Kubernetes 1.16, and must be removed before upgrading to EKS 1.16.
 - **Note**:
   - EKS 1.12 and later already creates "kube-proxy-config" during cluster creation. This is required if your EKS cluster(s) were created before Kubernetes version 1.12 and has been upgraded since leading into 1.16 version.
 - Check `kube-proxy` configuration on the cluster for `--resource-containers` flag by running below command,

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -183,7 +183,7 @@ The cluster update should finish in a few minutes\.
 Update `kube-proxy` on Cluster:
 - `kube-proxy --resource-containers` flag has been deprecated in [Kubernetes 1.16](https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.16.md#deprecations-and-removals). If your cluster was created and upgraded since EKS 1.11, your kube-proxy DaemonSet spec does not use configMap to pull configuration and has `--resource-containers` flag. This fails in Kubernetes 1.16, and must be removed before upgrading to EKS 1.16.
 - **Note**:
-  - EKS 1.12 and later already creates "kube-proxy-config" during cluster creation. This is only needed for EKS 1.10 and 1.11 clusters that being upgraded to EKS 1.16.
+  - EKS 1.12 and later already creates "kube-proxy-config" during cluster creation. This is required if your EKS cluster(s) were created before Kubernetes version 1.12 and has been upgraded since leading into 1.16 version.
 - Check `kube-proxy` configuration on the cluster for `--resource-containers` flag by running below command,
    ```
    kubectl get daemonset kube-proxy --namespace kube-system -o jsonpath={.spec.template.spec.containers[0].command}


### PR DESCRIPTION
*Issue #, if available:*

- `kube-proxy` on EKS cluster below version 1.12 
  - does not pull configuration from configMap, Instead config is passed as `command` argument for container.
  - `--random-fully` property is passed to kube-proxy which is not supported from kube-proxy versions 1.16.

*Description of changes:*
- This documentation will walk through on how to update kube-proxy manifest to 1.16 when `--random-fully` property is set.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
