### PR TITLE
Clarify documentation of what sunets will be used for internal load balancers

### DIFF
--- a/doc_source/load-balancing.md
+++ b/doc_source/load-balancing.md
@@ -27,7 +27,9 @@ You must tag the public subnets in your VPC so that Kubernetes knows to use only
 | --- | --- | 
 | `kubernetes.io/role/elb` | `1` | 
 
-Private subnets must be tagged in the following way so that Kubernetes knows it can use the subnets for internal load balancers\. Moreover, if in one Availability Zone just public subnets are tagged, the load balancers will use one of the public subnets instead of a private one\. If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
+Private subnets must be tagged in the following way so that Kubernetes prioritize to use the these subnets for internal load balancers instead of choosing a private subnet in each Availability Zone \(in lexicographical order by subnet ID\)\. If in one Availability Zone just public subnets are associated with the cluster, the load balancers will use one of the public subnets instead of the private one\. 
+
+If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
 
 
 | Key | Value | 

--- a/doc_source/load-balancing.md
+++ b/doc_source/load-balancing.md
@@ -27,7 +27,7 @@ You must tag the public subnets in your VPC so that Kubernetes knows to use only
 | --- | --- | 
 | `kubernetes.io/role/elb` | `1` | 
 
-Private subnets must be tagged in the following way so that Kubernetes prioritize to use the these subnets for internal load balancers instead of choosing a private subnet in each Availability Zone \(in lexicographical order by subnet ID\)\. If an Availability Zone just has public subnets associated with the cluster, the load balancers will use one of the public subnets instead of a private one\. 
+Private subnets must be tagged in the following way so that Kubernetes prioritize to use the these subnets for internal load balancers instead of choosing a not tagged private subnet in each Availability Zone. Notice that if an Availability Zone just has public subnets associated with the cluster, the load balancers will use one of the public subnets instead of a private one\. 
 
 If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
 

--- a/doc_source/load-balancing.md
+++ b/doc_source/load-balancing.md
@@ -27,7 +27,7 @@ You must tag the public subnets in your VPC so that Kubernetes knows to use only
 | --- | --- | 
 | `kubernetes.io/role/elb` | `1` | 
 
-Private subnets must be tagged in the following way so that Kubernetes knows it can use the subnets for internal load balancers\. If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
+Private subnets must be tagged in the following way so that Kubernetes knows it can use the subnets for internal load balancers\. Moreover, if in one Availability Zone just public subnets are tagged, the load balancers will use one of the public subnets instead of a private one\. If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
 
 
 | Key | Value | 

--- a/doc_source/load-balancing.md
+++ b/doc_source/load-balancing.md
@@ -27,7 +27,7 @@ You must tag the public subnets in your VPC so that Kubernetes knows to use only
 | --- | --- | 
 | `kubernetes.io/role/elb` | `1` | 
 
-Private subnets must be tagged in the following way so that Kubernetes prioritize to use the these subnets for internal load balancers instead of choosing a private subnet in each Availability Zone \(in lexicographical order by subnet ID\)\. If in one Availability Zone just public subnets are associated with the cluster, the load balancers will use one of the public subnets instead of the private one\. 
+Private subnets must be tagged in the following way so that Kubernetes prioritize to use the these subnets for internal load balancers instead of choosing a private subnet in each Availability Zone \(in lexicographical order by subnet ID\)\. If an Availability Zone just has public subnets associated with the cluster, the load balancers will use one of the public subnets instead of a private one\. 
 
 If you use an Amazon EKS AWS CloudFormation template to create your VPC after 03/26/2020, then the subnets created by the template are tagged when they're created\. For more information about the Amazon EKS AWS CloudFormation VPC templates, see [Creating a VPC for your Amazon EKS cluster](create-public-private-vpc.md)\.
 


### PR DESCRIPTION
*Issue #, if available:*

I found that if I create a internal load balancer for an EKS cluster, where not private subnets are tagged with “key: kubernetes.io/role/internal-elb Value: 1”, but there is at least one subnet associated with the cluster in a specific an Availability zone, by using the tag “key: kubernetes.io/cluster/qa-eps-eks, value: shared”. EKS it will create the load balancer choosing one of the associated private subnets in lexicographically order. Moreover if the Availability Zone has not a private subnets associated with the cluster,  a public subnet associated to the cluster will be added to the Load balancer instead.

This behavior is described in the algorithm that chooses the Load Balancers subnets [1]. Also I replicate this behavior in my Kubernetes cluster.

References:

[1]

*Description of changes:*

I would like to clarify how the subnets are chosen when internal Load Balancer is created. I will choose a private subnet per availability zone where there is a subnet associated to the cluster although no subnets has a tag “key: kubernetes.io/role/internal-elb Value: 1”

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
