### PR TITLE
Fix infrastructure-security.md

### DIFF
--- a/doc_source/infrastructure-security.md
+++ b/doc_source/infrastructure-security.md
@@ -2,7 +2,7 @@
 
 As a managed service, Amazon EKS is protected by the AWS global network security procedures that are described in the [Amazon Web Services: Overview of security processes](https://d0.awsstatic.com/whitepapers/Security/AWS_Security_Whitepaper.pdf) whitepaper\.
 
-You use AWS published API calls to access Amazon EKS through the network\. Clients must support Transport Layer Security \(TLS\) 1\.0 or later\. We recommend TLS 1\.2 or later\. Clients must also support cipher suites with perfect forward secrecy \(PFS\) such as Ephemeral Diffie\-Hellman \(DHE\) or Elliptic Curve Ephemeral Diffie\-Hellman \(ECDHE\)\. Most modern systems such as Java 7 and later support these modes\.
+You use AWS published API calls to access Amazon EKS through the network\. Clients must support Transport Layer Security \(TLS\) 1\.2 or later\. Clients must also support cipher suites with perfect forward secrecy \(PFS\) such as Ephemeral Diffie\-Hellman \(DHE\) or Elliptic Curve Ephemeral Diffie\-Hellman \(ECDHE\)\. Most modern systems such as Java 7 and later support these modes\.
 
 Additionally, requests must be signed by using an access key ID and a secret access key that is associated with an IAM principal\. Or you can use the [AWS Security Token Service](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) \(AWS STS\) to generate temporary security credentials to sign requests\.
 


### PR DESCRIPTION
Fixes issue #166 

Kubernetes default is VersionTLS12: https://github.com/kubernetes/kubernetes/blob/release-1.16/staging/src/k8s.io/component-base/cli/flag/ciphersuites_flag.go#L101

Unless we set --tls-min-version on kube-apiserver (https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/).

Description of changes:
Remove mention to 1.0 or later, and define clients must support Transport Layer Security TLS 1.2 or later.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
