### PR TITLE
Corrected kube-proxy image update section

### DIFF
--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -192,7 +192,7 @@ The cluster update should finish in a few minutes\.
        kube-proxy=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.17.7
    ```
 
-   Your account ID and region may differ from the example above\.
+   Your region may differ from the example above\.
 
 1. Check your cluster's DNS provider\. Clusters that were created with Kubernetes version 1\.10 shipped with `kube-dns` as the default DNS and service discovery provider\. If you have updated a 1\.10 cluster to a newer version and you want to use CoreDNS for DNS and service discovery, then you must install CoreDNS and remove `kube-dns`\.
 


### PR DESCRIPTION
Userguide is suggesting user to change the kube proxy image repository URL from `602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/kube-proxy:v1.16.12` to user's region and account ID but changing repository URL to user's aws account id will fail with an error since user does not have an  eks/kube-proxy image in their repo by default.

`xxxxxxxxx.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy:v1.16.12": rpc error: code = Unknown desc = Error response from daemon: repository xxxxxxxxx.dkr.ecr.eu-west-1.amazonaws.com/eks/kube-proxy not found: name unknown: The repository with name 'eks/kube-proxy' does not exist in the registry with id 'xxxxxxxxx'`

But if the user only change the region field and keep the account id same as in the userguide it will work, so I think it's a typo/mistake made by the author

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
