### PR TITLE
Fix URL for Linux kubectl 1.14 download.

### DIFF
--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -114,7 +114,7 @@ You must use a `kubectl` version that is within one minor version difference of 
    + **Kubernetes 1\.14:**
 
      ```
-     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.14.9/2020-07-08/;bin/linux/amd64/kubectl
+     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.14.9/2020-07-08/bin/linux/amd64/kubectl
      ```
 
 1. \(Optional\) Verify the downloaded binary with the SHA\-256 sum for your binary\.


### PR DESCRIPTION
Semicolon removed from URL which causes a Bash error when copy-pasting command into shell.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
