### PR TITLE
Update step 3 to provide link to current policy doc

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -41,7 +41,7 @@ You cannot use the ALB Ingress Controller with [Private clusters](private-cluste
        --approve
    ```
 
-1. Download an IAM policy for the ALB Ingress Controller pod that allows it to make calls to AWS APIs on your behalf\. You can view the [policy document](https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/iam-policy.json) on GitHub\.
+1. Download an IAM policy for the ALB Ingress Controller pod that allows it to make calls to AWS APIs on your behalf\. You can view the [policy document](https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json) on GitHub\.
 
    ```
    curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json


### PR DESCRIPTION
In step 3 where it states "You can view the policy document" - it was linked to a policy for v.1.1.4 which does not have the wafv2:GetWebACLForResource permissions that are now required for alb ingress. Changed the link to point to v.1.1.8 - the same policy retrieved in the curl command below it

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
