### PR TITLE
Fix label of eksctl tab of profile-creation

### DIFF
--- a/doc_source/fargate-profile.md
+++ b/doc_source/fargate-profile.md
@@ -61,7 +61,7 @@ You can optionally specify Kubernetes labels to match for the selector\. The sel
 This topic helps you to create a Fargate profile\. Your cluster must support Fargate \(beginning with Kubernetes version 1\.14 and [platform version](platform-versions.md) `eks.5`\)\. You also must have created a pod execution role to use for your Fargate profile\. For more information, see [Pod execution role](pod-execution-role.md)\. Pods running on Fargate are only supported on private subnets \(with [NAT gateway](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-nat-gateway.html) access to AWS services, but not a direct route to an Internet Gateway\), so your cluster's VPC must have private subnets available\. Select the tab of the tool that you'd like to use to create the profile\.
 
 ------
-#### [ AWS Fargate ]
+#### [ eksctl ]
 
 **To create a Fargate profile for a cluster with `eksctl`**
 


### PR DESCRIPTION
*Description of changes:*

The `eksctl` set of instructions for creating a Fargate Profile is labelled `AWS Fargate`, rather than eksctl. Contrast with, e.g., https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html, which labels it correctly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
