### PR TITLE
Fix typos in create-managed-node-group.md

### DIFF
--- a/doc_source/create-managed-node-group.md
+++ b/doc_source/create-managed-node-group.md
@@ -33,8 +33,8 @@ For more information on installing or upgrading `eksctl`, see [Installing or upg
     --node-type m5.large \
     --nodes 3 \
     --nodes-min 2 \
-    --nodes-min 4 \
-    --ssh--access \
+    --nodes-max 4 \
+    --ssh-access \
     --ssh-public-key my-public-key.pub \
     --managed
   ```


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

typos found under [eksctl] tab to create managed-node group:

```
eksctl create nodegroup \
  --cluster my-cluster \
  --region us-west-2 \
  --name my-mng \
  --node-type m5.large \
  --nodes 3 \
  --nodes-min 2 \
  --nodes-min 4 \  <---- should be nodes-max
  --ssh--access \    <---- extra "-", should be --ssh-access
  --ssh-public-key my-public-key.pub \
  --managed
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
