### PR TITLE
Updated github link for iam policy.

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -41,7 +41,7 @@ You cannot use the ALB Ingress Controller with [Private clusters](private-cluste
        --approve
    ```
 
-1. Download an IAM policy for the ALB Ingress Controller pod that allows it to make calls to AWS APIs on your behalf\. You can view the [policy document](https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.4/docs/examples/iam-policy.json) on GitHub\.
+1. Download an IAM policy for the ALB Ingress Controller pod that allows it to make calls to AWS APIs on your behalf\. You can view the [policy document](https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/master/docs/examples/iam-policy.json) on GitHub\.
 
    ```
    curl -o iam-policy.json https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/iam-policy.json


### PR DESCRIPTION



*Issue #, if available:*

This PR Avoid this error:

AccessDeniedException: User: arn:aws:sts::xxxxxxx:assumed-role/role0001/yyyyyy is not authorized to perform: wafv2:GetWebACLForResource on resource: arn:aws:wafv2:us-east-1:xxxxxx:regional/webacl

*Description of changes:*
The Link for github was hard-coded to 1.14. With the new version it will miss waf2 policies.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
