### PR TITLE
Remove a Note that no longer applies

### DIFF
--- a/doc_source/cluster-endpoint.md
+++ b/doc_source/cluster-endpoint.md
@@ -11,9 +11,6 @@ Because this endpoint is for the Kubernetes API server and not a traditional AWS
 
 When you enable endpoint private access for your cluster, Amazon EKS creates a Route 53 private hosted zone on your behalf and associates it with your cluster's VPC\. This private hosted zone is managed by Amazon EKS, and it doesn't appear in your account's Route 53 resources\. In order for the private hosted zone to properly route traffic to your API server, your VPC must have `enableDnsHostnames` and `enableDnsSupport` set to `true`, and the DHCP options set for your VPC must include `AmazonProvidedDNS` in its domain name servers list\. For more information, see [Updating DNS support for your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/vpc-dns.html#vpc-dns-updating) in the *Amazon VPC User Guide*\.
 
-**Note**  
-In addition to standard Amazon EKS permissions, your IAM user or role must have `route53:AssociateVPCWithHostedZone` permissions to enable the cluster's endpoint private access\.
-
 You can define your API server endpoint access requirements when you create a new cluster, and you can update the API server endpoint access for a cluster at any time\. 
 
 ## Modifying cluster endpoint access<a name="modify-endpoint-access"></a>


### PR DESCRIPTION
With introduction of EKS Service Linked role, which includes "route53:AssociateVPCWithHostedZone", this note is no longer required.

*Description of changes:*
To avoid customers' confusion, suggest to remove this note.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
