### PR TITLE
Bump CNI config reference to v1.7

### DIFF
--- a/doc_source/calico.md
+++ b/doc_source/calico.md
@@ -11,7 +11,7 @@ Calico adds rules to `iptables` on the node that may be higher priority than exi
 1. Apply the Calico manifest from the [`aws/amazon-vpc-cni-k8s` GitHub project](https://github.com/aws/amazon-vpc-cni-k8s)\. This manifest creates DaemonSets in the `kube-system` namespace\.
 
    ```
-   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/calico.yaml
+   kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/calico.yaml
    ```
 
 1. Watch the `kube-system` DaemonSets and wait for the `calico-node` DaemonSet to have the `DESIRED` number of pods in the `READY` state\. When this happens, Calico is working\.
@@ -31,7 +31,7 @@ Calico adds rules to `iptables` on the node that may be higher priority than exi
 + If you are done using Calico in your Amazon EKS cluster, you can delete the DaemonSet with the following command:
 
   ```
-  kubectl delete -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.6/config/v1.6/calico.yaml
+  kubectl delete -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/calico.yaml
   ```
 
 ## Stars policy demo<a name="calico-stars-demo"></a>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Using the [latest](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.7.1) released [aws-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s) version in Calico docs.

I have a [PR in process](https://github.com/aws/amazon-vpc-cni-k8s/pull/1182) which will eventually be merged into `release-1.7`, making https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/calico.yaml bump Calico version to `v3.15.1` an upgrade from `v3.13.4`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
