### PR TITLE
Remove that SG with cluster tag is optional

### DIFF
--- a/doc_source/sec-group-reqs.md
+++ b/doc_source/sec-group-reqs.md
@@ -76,7 +76,7 @@ To allow proxy functionality on privileged ports or to run the CNCF conformance 
 
 \*Nodes also require access to the Amazon EKS APIs for cluster introspection and node registration at launch time either through the internet or VPC endpoints\. To pull container images, they require access to the Amazon S3 and Amazon ECR APIs \(and any other container registries, such as DockerHub\)\. For more information, see [AWS IP address ranges](https://docs.aws.amazon.com/general/latest/gr/aws-ip-ranges.html) in the *AWS General Reference* and [Private clusters](private-clusters.md)\.
 
-If you have more than one security group associated to your nodes, then one of the security groups must have the following tag applied to it\. If you have only one security group associated to your nodes, then the tag is optional\. For more information about tagging, see [Working with tags using the console](eks-using-tags.md#tag-resources-console)\.
+If you have more than one security group associated to your nodes, then one of the security groups must have the following tag applied to it\. For more information about tagging, see [Working with tags using the console](eks-using-tags.md#tag-resources-console)\.
 
 
 | Key | Value | 


### PR DESCRIPTION
*Issue #, if available:*

There is the following description about Cluster Tag of Security Group of worker node.

https://github.com/awsdocs/amazon-eks-user-guide/blob/67679eae87884765fc7fdd4e4d6344074dacddd6/doc_source/sec-group-reqs.md

> If you have only one security group associated to your nodes, then the tag is optional.

I think this is not an option.
When the service controller creates an NLB, it checks both security group with cluster tag and security group attached to instances.

https://github.com/kubernetes/kubernetes/blob/v1.17.9/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L3719

```
func (c *Cloud) EnsureLoadBalancer(ctx context.Context, clusterName string, apiService *v1.Service, nodes []*v1.Node) (*v1.LoadBalancerStatus, error) {
	annotations := apiService.Annotations
...
		err = c.updateInstanceSecurityGroupsForNLB(loadBalancerName, instances, sourceRangeCidrs, v2Mappings)
```

But the service controller deletes an NLB, it checks only security group with cluster tag.

https://github.com/kubernetes/kubernetes/blob/v1.17.9/staging/src/k8s.io/legacy-cloud-providers/aws/aws.go#L4298

```
func (c *Cloud) EnsureLoadBalancerDeleted(ctx context.Context, clusterName string, service *v1.Service) error {
	loadBalancerName := c.GetLoadBalancerName(ctx, clusterName, service)
...
		return c.updateInstanceSecurityGroupsForNLB(loadBalancerName, nil, nil, nil)
```

This means that if the security group attached to the instance does not have a cluster tag, the NLB inbound rules are not deleted.

Therefore, I think this description should be removed.

*Description of changes:*

I remove only the above description.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
