### PR TITLE
Update cluster-autoscaler.md

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -125,7 +125,7 @@ If you used the previous `eksctl` commands to create your node groups, these tag
 1. Add the `cluster-autoscaler.kubernetes.io/safe-to-evict` annotation to the deployment with the following command\.
 
    ```
-   kubectl -n kube-system annotate deployment.apps/cluster-autoscaler cluster-autoscaler.kubernetes.io/safe-to-evict="false"
+   kubectl -n kube-system patch deployment cluster-autoscaler -p '{"spec":{"template":{"metadata":{"annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}}}}}'
    ```
 
 1. Edit the Cluster Autoscaler deployment with the following command\.


### PR DESCRIPTION
*Issue #, if available:*
The command for adding annotation is incorrect. 

Incorrect:
kubectl -n kube-system annotate deployment.apps/cluster-autoscaler cluster-autoscaler.kubernetes.io/safe-to-evict="false"

apiVersion: apps/v1
kind: Deployment
metadata:
  annotations:
    cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
  labels:
    app: cluster-autoscaler
  name: cluster-autoscaler
  namespace: kube-system
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: cluster-autoscaler
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        prometheus.io/port: "8085"
        prometheus.io/scrape: "true"
      creationTimestamp: null

This will add under metadata of deployment which is wrong. Pod will not have these annotations. Cluster autoscaler pod did not have this annotation and got evicted.

For pods, it should be under spec -> template -> metadata -> annotations in deployment kind.

*Description of changes:*

Correct command :
kubectl -n kube-system patch deployment cluster-autoscaler -p '{"spec":{"template":{"metadata":{"annotations":{"cluster-autoscaler.kubernetes.io/safe-to-evict": "false"}}}}}'

This creates the annotation under right resource. 
Tested and working as expected.

apiVersion: apps/v1
kind: Deployment
metadata:
  labels:
    app: cluster-autoscaler
  name: cluster-autoscaler
  namespace: kube-system
spec:
  progressDeadlineSeconds: 600
  replicas: 1
  revisionHistoryLimit: 10
  selector:
    matchLabels:
      app: cluster-autoscaler
  strategy:
    rollingUpdate:
      maxSurge: 25%
      maxUnavailable: 25%
    type: RollingUpdate
  template:
    metadata:
      annotations:
        **cluster-autoscaler.kubernetes.io/safe-to-evict: "false"**
        prometheus.io/port: "8085"
        prometheus.io/scrape: "true"
      creationTimestamp: null


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
