### PR TITLE
patch cluster-autoscaler deployment to run on bottlerocket worker nodes

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -157,6 +157,11 @@ If you used the previous `eksctl` commands to create your node groups, these tag
 
 1. Open the Cluster Autoscaler [releases](https://github.com/kubernetes/autoscaler/releases) page in a web browser and find the latest Cluster Autoscaler version that matches your cluster's Kubernetes major and minor version\. For example, if your cluster's Kubernetes version is 1\.17 find the latest Cluster Autoscaler release that begins with 1\.17\. Record the semantic version number \(1\.17\.*`n`*\) for that release to use in the next step\.
 
+1. (Optional) If you are using BottleRocket Worker nodes , you need replace the host path for the volume "ssl-certs" as the ca-bundle is located in a different path
+
+   ```
+   kubectl patch deployment cluster-autoscaler -n kube-system --type json -p='[{"op": "replace", "path": "/spec/template/spec/volumes/0/hostPath/path" , "value":"/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt"}]
+   ```
 1. Set the Cluster Autoscaler image tag to the version that you recorded in the previous step with the following command\. Replace *1\.15\.n* with your own value\. You can replace `us` with `asia` or `eu`\.
 
    ```

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -197,6 +197,21 @@ The cluster update should finish in a few minutes\.
                             - amd64
                             - arm64
       ```
+   1. \(Optional\) if you originally created an Amazon EKS cluster with Kubernetes version 1.13 or earilier and intend to use fargate , then edit your `kube-proxy` manifest to include a NodeAffinity rule to prevent kube-proxy pods from trying to be scheduled on fargate nodes . This is a one\-time operation\. Once you've added the Affinity rule to your manifest, you don't need to do it each time you upgrade\. If you cluster was oriniginally created with kubernetes v1.14 or later , then `kube-proxy` is already including this Affinity rule \.
+
+     ```
+      kubectl edit -n kube-system daemonset/kube-proxy
+      ```
+
+      Add the following Affinity Rule to the file in the editor and then save the file\. For an example of where to include this text in the editor, see the [CNI manifest](https://github.com/aws/amazon-vpc-cni-k8s/blob/release-1.6/config/v1.6/aws-k8s-cni.yaml#L95-%23L97) file on GitHub\. 
+
+      ```
+     - key: eks.amazonaws.com/compute-type
+                operator: NotIn
+                values:
+                - fargate
+
+      ```
 
 1. Check your cluster's DNS provider\. Clusters that were created with Kubernetes version 1\.10 shipped with `kube-dns` as the default DNS and service discovery provider\. If you have updated a 1\.10 cluster to a newer version and you want to use CoreDNS for DNS and service discovery, then you must install CoreDNS and remove `kube-dns`\.
 


### PR DESCRIPTION
*Issue #, if available:*

The ca-bundle.crt file is not in this path /etc/ssl/certs/  in bottlerocket AMI , so deploying this will cause the error 

mounting "/etc/ssl/certs/ca-bundle.crt" to rootfs at "/run/containerd/io.containerd.runtime.v2.task/k8s.io/cluster-autoscaler/rootfs/etc/ssl/certs/ca-certificates.crt" caused: not a directory: unknown


*Description of changes:*

Added an optional patch command for using with bottlerocket nodes , the file is located in this path :
/x86_64-bottlerocket-linux-gnu/sys-root/usr/share/factory/etc/pki/tls/certs/ca-bundle.crt



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
