### PR TITLE
Suggest the simpler "annotate" command instead of a JSON patch

### DIFF
--- a/doc_source/storage-classes.md
+++ b/doc_source/storage-classes.md
@@ -54,7 +54,7 @@ This topic uses the [in\-tree Amazon EBS storage provisioner](https://kubernetes
 1. Choose a storage class and set it as your default by setting the `storageclass.kubernetes.io/is-default-class=true` annotation\.
 
    ```
-   kubectl patch storageclass <gp2> -p '{"metadata": {"annotations":{"storageclass.kubernetes.io/is-default-class":"true"}}}'
+   kubectl annotate storageclass gp2 storageclass.kubernetes.io/is-default-class=true
    ```
 
    Output:


### PR DESCRIPTION
This is super minor, so feel free to disregard if it doesn't fit with the
general AWS style guide; but `kubectl annotate` is simpler than the
longer `kubectl patch`.

I also replaced `<gp2>` with `gp2` for consistency. (I understand that
`<>` is used in some places in the docs as a placeholder, but since
all other places in this doc use `gp2`, I thought it would avoid issues
if someone copy-pastes the command blindly.)

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
