### PR TITLE
Resvise the way to launch nodegroup for AWS Outposts

### DIFF
--- a/doc_source/eks-on-outposts.md
+++ b/doc_source/eks-on-outposts.md
@@ -55,18 +55,8 @@ An Outpost is an extension of an AWS Region, and you can extend a VPC in an acco
       --resources-vpc-config  subnetIds=<subnet-xxxxxxxx>,<subnet-yyyyyyyy>,securityGroupIds=<sg-xxxxxxxx>
    ```
 
-1. Create the node group\. Specify an instance type that is available on your Outpost\. \(This step is different for AWS Outposts\.\)
+1. Create the node group\. You can launch [self-managed nodes using the AWS Management Console](https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html#launch-al-nodes-console). After you've open the AWS CloudFormation template, enter values as described in the instruction. For the **NodeInstanceType** field, specify an instance type that is available on your Outpost\. \(This step is different for AWS Outposts\.\)
 
-   ```
-   eksctl create nodegroup --cluster <eks-outpost> \
-          --version    auto \
-          --name       <outpost-nodes> \
-          --node-type  <c5.large> \
-          --node-ami   auto \
-          --nodes      3 \
-          --nodes-min  1 \
-          --nodes-max  4
-   ```
 
 1. Deploy applications and services\.
 


### PR DESCRIPTION
*Issue #, if available:*

The current steps in the documentation is using AWS CLI command to create EKS cluster, however, due to the EKS cluster was not created and managed by eksctl, the eksctl need to look up CloudFormation stack with specific tag/suffix to get cluster configuration[(#L189-L209)](https://github.com/weaveworks/eksctl/blob/78be244972c41b9658f048301f106ee6a378a085/pkg/cfn/manager/cluster.go#L189-L209). In this case, eksctl might report error(`no eksctl-managed CloudFormation stacks found for <...>`) when trying to create nodegroup for that cluster out of its control, as below:

```
❯ ./eksctl create nodegroup --cluster myOutPostCluster --name myOutPostCluster-nodes --node-type c5.xlarge .... --region us-west-2
[ℹ]  eksctl version 0.30.0-rc.1
[ℹ]  using region us-west-2
[ℹ]  will use version 1.18 for new nodegroup(s) based on control plane version
Error: getting existing configuration for cluster "myOutPostCluster": no eksctl-managed CloudFormation stacks found for "myOutPostCluster"
```
- See: https://github.com/weaveworks/eksctl/issues/877


*Description of changes:*

Change it to use CloudFormation template to launch self-managed nodegroup. But I don't have outpost environment, need to verify to see if this is correct.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
