### PR TITLE
Make the CoreDNS ConfigMap check more precise

### DIFF
--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -64,7 +64,7 @@ Update the cluster and Kubnernetes add\-ons\.
    1. Check to see if your CoreDNS manifest has the line\.
 
       ```
-      kubectl get configmap coredns -n kube-system -o yaml |grep upstream
+      kubectl get configmap coredns -n kube-system -o jsonpath='{$.data.Corefile}' | grep upstream
       ```
 
       If no output is returned, your manifest doesn't have the line and you can skip to the next step to update your cluster\. If output is returned, then you need to remove the line\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The current command will give you a false positive, even after removing
the `upstream` line, because it's still in the yaml under `last-applied-configuration`.

Example:
  Even after removing the `upstream` config option, I expect to get an
  empty response, but I see this instead:
```
kubectl get configmap coredns -n kube-system -o yaml | grep upstream
      {"apiVersion":"v1","data":{"Corefile":".:53 {\n    errors\n    health\n    kubernetes cluster.local in-addr.arpa ip6.arpa {\n      pods insecure\n      upstream\n      fallthrough in-addr.arpa ip6.arpa\n    }\n    prometheus :9153\n    forward . /etc/resolv.conf\n    cache 30\n    loop\n    reload\n    loadbalance\n}\n"},"kind":"ConfigMap","metadata":{"annotations":{},"labels":{"eks.amazonaws.com/component":"coredns","k8s-app":"kube-dns"},"name":"coredns","namespace":"kube-system"}}
```

This PR adds `-o jsonpath='{$.data.Corefile}'` to narrow it down to just
the actual coredns config before passing it off to grep. No more false
positives! :)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
