### PR TITLE
Update security-groups-for-pods.md

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -48,7 +48,7 @@ Before deploying security groups for pods, consider the following limits and con
 1. If are you using liveness or readiness probes, you also need to disable TCP early demux, so that the kubelet can connect to pods on branch network interfaces via TCP. To do this run the following command:
 
    ```
-   kubectl edit ds aws-node -nkube-system
+   kubectl edit ds aws-node -n kube-system
    ```
 Under the `initContainer` section, change the value for `DISABLE_TCP_EARLY_DEMUX` from `false` to `true`, and save the file.
 

--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -44,6 +44,13 @@ Before deploying security groups for pods, consider the following limits and con
    ```
    kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
    ```
+   
+1. Disable TCP early demux by setting `DISABLE_TCP_EARLY_DEMUX` to `true` in the `aws-node` DaemonSet init container. This is required for the kubelet to connect via TCP to pods for liveness or readiness probes.
+
+   ```
+   kubectl edit ds aws-node -nkube-system
+   ```
+
 **Note**  
 The trunk network interface is included in the maximum number of network interfaces supported by the instance type\. For a list of the maximum number of interfaces supported by each instance type, see [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) in the *Amazon EC2 User Guide for Linux Instances*\. If your node already has the maximum number of standard network interfaces attached to it then the VPC resource controller will reserve a space\. You will have to scale down your running pods enough for the controller to detach and delete a standard network interface, create the trunk network interface, and attach it to the instance\.
 

--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -45,11 +45,12 @@ Before deploying security groups for pods, consider the following limits and con
    kubectl set env daemonset aws-node -n kube-system ENABLE_POD_ENI=true
    ```
    
-1. Disable TCP early demux by setting `DISABLE_TCP_EARLY_DEMUX` to `true` in the `aws-node` DaemonSet init container. This is required for the kubelet to connect via TCP to pods for liveness or readiness probes.
+1. If are you using liveness or readiness probes, you also need to disable TCP early demux, so that the kubelet can connect to pods on branch network interfaces via TCP. To do this run the following command:
 
    ```
    kubectl edit ds aws-node -nkube-system
    ```
+Under the `initContainer` section, change the value for `DISABLE_TCP_EARLY_DEMUX` from `false` to `true`, and save the file.
 
 **Note**  
 The trunk network interface is included in the maximum number of network interfaces supported by the instance type\. For a list of the maximum number of interfaces supported by each instance type, see [IP addresses per network interface per instance type](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-eni.html#AvailableIpPerENI) in the *Amazon EC2 User Guide for Linux Instances*\. If your node already has the maximum number of standard network interfaces attached to it then the VPC resource controller will reserve a space\. You will have to scale down your running pods enough for the controller to detach and delete a standard network interface, create the trunk network interface, and attach it to the instance\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adding step to set DISABLE_TCP_EARLY_DEMUX to true for pods liveness or readiness probes to succeed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
