### PR TITLE
Mention additional IAM policies required for upgrade

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -97,6 +97,8 @@ This topic shows you how to configure the AWS load balancer controller to work w
       kubectl delete -f https://raw.githubusercontent.com/kubernetes-sigs/aws-alb-ingress-controller/v1.1.8/docs/examples/rbac-role.yaml
       ```
 
+   1. Grant [additional IAM policy](https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy_v1_to_v2_additional.json) needed for migration to the new controller
+
 1. Install the AWS load balancer controller using Helm\. If you'd prefer to install the controller manually, then skip to the next step\.
 
    1. Install the `TargetGroupBinding` custom resource definitions\.


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1577
https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1578

*Description of changes:*
When upgrading from AWS ALB ingress controller to the new AWS Load Balancer controller, additional IAM policies need to be granted for controller to work properly after migration. Mention the step in the AWS documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
