### PR TITLE
update version for metric-server, since v0.3.6 does not support arm i…

### DIFF
--- a/doc_source/metrics-server.md
+++ b/doc_source/metrics-server.md
@@ -7,7 +7,7 @@ The Kubernetes Metrics Server is an aggregator of resource usage data in your cl
 1. Deploy the Metrics Server with the following command:
 
    ```
-   kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.6/components.yaml
+   kubectl apply -f https://github.com/kubernetes-sigs/metrics-server/releases/download/v0.3.7/components.yaml
    ```
 
 1. Verify that the `metrics-server` deployment is running the desired number of pods with the following command\.


### PR DESCRIPTION
…nstance

*Issue #, if available:*
v0.3.6 does not support arm instance
*Description of changes:*
since v0.3.7 already released, and the docker image support multiple architectures, so would you please update the image version to v0.3.7

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
