### PR TITLE
[chore] AWS release date for EKS 1.18 (10/13/20)

### DIFF
--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -127,7 +127,7 @@ Dates with only a month and a year are approximate and are updated with an exact
 | 1\.15 | June 19, 2019 | March 10, 2020 | May, 2021 | 
 | 1\.16 | Septermber 8, 2019 | April 30, 2020 | July, 2021 | 
 | 1\.17 | December 9, 2019 | July 10, 2020 | September, 2021 | 
-| 1\.18 | March 23, 2020 | October, 2020 | November, 2021 | 
+| 1\.18 | March 23, 2020 | October 13, 2020 | November, 2021 | 
 | 1\.19 | August 26, 2020 | January, 2021 | February, 2022 | 
 
 ## Amazon EKS version support and FAQ<a name="version-deprecation"></a>


### PR DESCRIPTION
*Issue #, if available:*
no

*Description of changes:*
According to [AWS Blog post](https://aws.amazon.com/fr/about-aws/whats-new/2020/10/amazon-eks-supports-kubernetes-version-1-18/) AWS release date's for EKS is October 13, 2020

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
