### PR TITLE
Update CNI upgrade docs to include security context info

### DIFF
--- a/doc_source/cni-upgrades.md
+++ b/doc_source/cni-upgrades.md
@@ -4,6 +4,13 @@ When you launch an Amazon EKS cluster, we apply a recent version of the [Amazon 
 
 The latest version that we recommend  is version 1\.7\.5\. You can view the different releases available for the plugin, and read the release notes for each version [on GitHub](https://github.com/aws/amazon-vpc-cni-k8s/releases)\.
 
+Starting from CNI version 1.7.0 and above, we removed [privileged](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.6/aws-k8s-cni.yaml#L130-L131) container capabilities and updated `securityContext` with just [`NET_ADMIN`](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.7/aws-k8s-cni.yaml#L177-L180) capabilities which is required for aws-node container to add iptables, ip routes and ip rules to setup pod networking.
+Also as part of this change, we added an init container which is a [privileged](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.7/aws-k8s-cni.yaml#L195-L206) container to setup reverse path filter, copy loopback plugins during aws-node pod start up. 
+
+**Important note:**
+If you are using custom PSP to enable fine-grained authorization of pod, this is a breaking change as it requires ` allowedCapabilities: - NET_ADMIN` in PSP along with `hostNetwork: true` and `privileged: true`
+
+
 Use the following procedures to check your CNI plugin version and upgrade to the latest recommended version\.
 
 **To check your Amazon VPC CNI plugin for Kubernetes version**


### PR DESCRIPTION
*Issue #, if available:*  https://github.com/aws/amazon-vpc-cni-k8s/issues/1278

*Description of changes:*
Updated CNI upgrade docs to provide more context on security context changes and init container info


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
