### PR TITLE
Adding ALB-Ingress 2 flags for Fargate profile

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -153,6 +153,17 @@ This topic shows you how to configure the AWS load balancer controller to work w
           --set serviceAccount.name=aws-load-balancer-controller \
           -n kube-system
         ```
+      + If you are using deploying to Fargate, you need to specify the `region` and `vpcId` flags to let the controller know the environment\.
+
+        ```
+        helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller \
+          --set clusterName=<cluster-name> \
+          --set serviceAccount.create=false \
+          --set region=<region-code> \
+          --set vpcId=<vpc-xxxxxxxx>> \
+          --set serviceAccount.name=aws-load-balancer-controller \
+          -n kube-system
+        ```
       + Beijing and Ningxia China Regions\.
 
         ```

--- a/doc_source/best-practices-security.md
+++ b/doc_source/best-practices-security.md
@@ -8,6 +8,9 @@ By default, the Amazon EC2 [instance metadata service](https://docs.aws.amazon.c
 + You’ve implemented IAM roles for service accounts and have assigned necessary permissions directly to all pods that require access to AWS services\.
 + No pods in your cluster require access to IMDS for other reasons, such as retrieving the current Region\. 
 
+**Important**
+If you use the [AWS load balancer controller](alb-ingress.md) in your EKS cluster, and block pod access to IMDS or deploying to Fargate, you need to specify the `region` and `vpcId` flags to let the controller know the environment\.
+
 For more information, see [Retrieving Security Credentials from Instance Metadata](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials)\. You can prevent access to IMDS from your instance and containers using one of the following options\.
 + **Block access to IMDSv1 from the node and all containers and block access to IMDSv2 for all containers that don't use host networking** – Your instance and pods that have `hostNetwork: true` in their pod spec use host networking\. To implement this option, complete the steps in the row and column that apply to your situation\.    
 [\[See the AWS documentation website for more details\]](http://docs.aws.amazon.com/eks/latest/userguide/best-practices-security.html)


### PR DESCRIPTION
*Issue #, if available:*

* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/1561

*Description of changes:*

* As the issue mention, `EC2Metadata` is not available in Fargate. Add the following section for Fargate with `region` and `vpcId` flags.

```
helm upgrade -i aws-load-balancer-controller eks/aws-load-balancer-controller \
    --set clusterName=<cluster-name> \
    --set serviceAccount.create=false \
    --set region=<region-code> \
    --set vpcId=<vpc-xxxxxxxx>> \
    --set serviceAccount.name=aws-load-balancer-controller \
    -n kube-system
```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
