### PR TITLE
Set the backup extension for sed's in-place argument

### DIFF
--- a/doc_source/cni-upgrades.md
+++ b/doc_source/cni-upgrades.md
@@ -55,7 +55,7 @@ Use the following procedures to check your CNI plugin version and upgrade to the
     + Replace `<region-code>` in the following command with the Region that your cluster is in and then run the modified command to replace the Region code in the file \(currently `us-west-2`\)\.
 
       ```
-      sed -i -e 's/us-west-2/<region-code>/' aws-k8s-cni.yaml
+      sed -i '.bak' -e 's/us-west-2/<region-code>/' aws-k8s-cni.yaml
       ```
     + Apply the manifest file to your cluster\.
 


### PR DESCRIPTION
The `-i` option requires an extension argument on macOS

As there doesn't seem to be a reasonably portable variant that doesn't produce backups (see https://stackoverflow.com/questions/4247068/sed-command-with-i-option-failing-on-mac-but-works-on-linux) this simply lets sed produce a .bak file.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
