### PR TITLE
Added note for ENIConfig `spec.securityGroups` property

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -76,11 +76,13 @@ The procedure in this topic instructs the CNI plugin to associate different secu
         subnet: <subnet-011b111c1f11fdf11>
       ```
 **Note**  
-Each subnet and security group combination requires its own custom resource\. If you have multiple subnets in the same Availability Zone, use the following command to annotate the nodes in each subnet with the matching config name\.  
+- Each subnet and security group combination requires its own custom resource\. If you have multiple subnets in the same Availability Zone, use the following command to annotate the nodes in each subnet with the matching config name\.  
 
       ```
       kubectl annotate node <node-name>.<region>.compute.internal k8s.amazonaws.com/eniConfig=<subnet1ConfigName>
       ```
+
+- Ensure that `spec.securityGroups` property exists with Security Group Id from same VPC for ENIConfig CustomResourceDefinition manifest. If not exists, aws-cni will assign Default Security Group from VPC to Secondary ENI's of the worker node.
 
    1. Apply each custom resource file that you created to your cluster with the following command:
 
@@ -88,7 +90,7 @@ Each subnet and security group combination requires its own custom resource\. If
       kubectl apply -f <us-west-2a>.yaml
       ```
 
-   1. \(Optional, but recommended for multi\-Availability Zone node groups\) By default, Kubernetes applies the Availability Zone of a node to the `failure-domain.beta.kubernetes.io/zone` label\. If you named your ENIConfig custom resources after each Availability Zone in your VPC, as recommended in step 6a, then you can enable Kubernetes to automatically apply the corresponding ENIConfig for the node's Availability Zone with the following command\.
+   2. \(Optional, but recommended for multi\-Availability Zone node groups\) By default, Kubernetes applies the Availability Zone of a node to the `failure-domain.beta.kubernetes.io/zone` label\. If you named your ENIConfig custom resources after each Availability Zone in your VPC, as recommended in step 6a, then you can enable Kubernetes to automatically apply the corresponding ENIConfig for the node's Availability Zone with the following command\.
 
       ```
       kubectl set env daemonset aws-node -n kube-system ENI_CONFIG_LABEL_DEF=failure-domain.beta.kubernetes.io/zone


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
- This pull request will add notes about `spec.securityGroups` property for ENIConfig manifest.
- When this property is not provided, aws-cni will add default security group from VPC to secondary ENI's of the worker node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
