### PR TITLE
Fix prefixed label

### DIFF
--- a/doc_source/managed-node-groups.md
+++ b/doc_source/managed-node-groups.md
@@ -31,6 +31,6 @@ If you are running a stateful application across multiple Availability Zones tha
 + Managed nodegroups cannot be deployed to nodes on [AWS Outposts](eks-on-outposts.md) or to nodes deployed in AWS Wavelength or AWS Local Zones\.
 + You can create multiple managed node groups within a single cluster\. For example, you could create one node group with the standard Amazon EKS optimized Amazon Linux 2 AMI for some workloads and another with the GPU variant for workloads that require GPU support\.
 + If your managed node group encounters a health issue, Amazon EKS returns an error message to help you to diagnose the issue\. For more information, see [Managed node group errors](troubleshooting.md#troubleshoot-managed-node-groups)\.
-+ Amazon EKS adds Kubernetes labels to managed node group instances\. These Amazon EKS provided labels are prefixed with `eks.amazon.com`\.
++ Amazon EKS adds Kubernetes labels to managed node group instances\. These Amazon EKS provided labels are prefixed with `eks.amazonaws.com`\.
 + Amazon EKS automatically drains nodes using the Kubernetes API during terminations or updates\. Updates respect the pod disruption budgets that you set for your pods\.
 + There are no additional costs to use Amazon EKS managed node groups\. You only pay for the AWS resources that you provision\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The right prefix is `eks.amazonaws.com`, not `eks.amazon.com`
Here is an example 
```
    eks.amazonaws.com/capacityType: ON_DEMAND
    eks.amazonaws.com/nodegroup: prod
    eks.amazonaws.com/nodegroup-image: ami-0740dfd28c11c9341
```