### PR TITLE
Update delete-managed-node-group.md

### DIFF
--- a/doc_source/delete-managed-node-group.md
+++ b/doc_source/delete-managed-node-group.md
@@ -2,7 +2,7 @@
 
 This topic describes how you can delete an Amazon EKS managed node group\.
 
-When you delete a managed node group, Amazon EKS randomly selects a node in your node group and sends a termination signal to the Auto Scaling group\. After which, Amazon EKS then sends a signal to drain the pods from the node\. If pods don't drain from a node for 15 minutes, then the pods are deleted\. This can happen, for example, when a pod disruption budget is too restrictive\. After the node is drained, it is terminated\. This step is repeated until all of the nodes in the Auto Scaling group are terminated, and then the Auto Scaling group is deleted\.
+When you delete a managed node group, Amazon EKS will first set the minimum, maximum and desired size of your Auto Scaling group to 0, which will trigger a scale down of your node group\. Before each instance is terminated, Amazon EKS will first send a signal to drain the pods from that node and wait a few minutes\. If the pods haven't drained after a few minutes, Amazon EKS will let Auto Scaling continue the termination of the instance\. Once all instances are terminated, the Auto Scaling group is deleted\. 
 
 **Important**  
 If you delete a managed node group that uses a node IAM role that isn't used by any other managed node group in the cluster, the role is removed from the [`aws-auth` ConfigMap](add-user-role.md)\. If any self\-managed node groups in the cluster are using the same node IAM role, the self\-managed nodes move to the `NotReady` status, and the cluster operation are also disrupted\. You can add the mapping back to the ConfigMap to minimize disruption\.


### PR DESCRIPTION
Changes to description to better reflect how deleting a managed nodegroup works.

*Issue #, if available:*

*Description of changes:*
The description earlier claimed that that nodes would be terminated one at a time. Updating this description to show that the size of the  Auto Scaling group is set to 0, which leads to AutoScaling group attempting to terminate multiple instances at once.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
