### PR TITLE
Update security-groups-for-pods.md

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -40,10 +40,10 @@ Before deploying security groups for pods, consider the following limits and con
    The output is similar to the following output\.
 
    ```
-   amazon-k8s-cni:<1.7.1>
+   amazon-k8s-cni:<1.7.7>
    ```
 
-   If your CNI plugin version is earlier than 1\.7\.1, then upgrade your CNI plugin to version 1\.7\.1 or later\. For more information, see [Amazon VPC CNI plugin for Kubernetes upgrades](cni-upgrades.md)\.
+   If your CNI plugin version is earlier than 1\.7\.7, then upgrade your CNI plugin to version 1\.7\.7 or later\. For more information, see [Amazon VPC CNI plugin for Kubernetes upgrades](cni-upgrades.md)\.
 
 1. Add the `AmazonEKSVPCResourceController` managed policy to the [cluster role](service_IAM_role.md#create-service-role) that is associated with your Amazon EKS cluster\. The [policy](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/AmazonEKSVPCResourceController$jsonEditor) allows the role to manage network interfaces, their private IP addresses, and their attachment and detachment to and from instances\. The following command adds the policy to a cluster role named `<eksClusterRole>`\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
amazon-vpc-cni-k8s has following bug fixes required for this feature
1.7.3 - Adds DISABLE_TCP_EARLY_DEMUX supports and 1.7.7 has some optimization to skip querying APIServer for some pods.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
