### PR TITLE
Fix broken link for aws-efs-csi-driver

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -14,12 +14,12 @@ For detailed descriptions of the available parameters and complete examples that
   + All Regions other than China Regions\.
 
     ```
-    kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.0"
+    kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/tree/release-1.0/deploy/kubernetes/overlays/stable/ecr"
     ```
   + Beijing and Ningxia China Regions\.
 
     ```
-    kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.0"
+    kubectl apply -k "github.com/kubernetes-sigs/aws-efs-csi-driver/tree/release-1.0/deploy/kubernetes/overlays/stable"
     ```
 
   If your cluster contains only Fargate pods \(no nodes\), then deploy the driver with the following command\.


### PR DESCRIPTION
*Issue #, if available:*
The link for efs-csi-driver has been broken.

*Description of changes:*
Fix broken link

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
