### PR TITLE
Update fargate-logging.md

### DIFF
--- a/doc_source/fargate-logging.md
+++ b/doc_source/fargate-logging.md
@@ -59,7 +59,7 @@ In the following steps, replace the `<example values>` with your own values\.
                  region <us-east-1>
                  log_group_name fluent-bit-cloudwatch
                  log_stream_prefix from-fluent-bit-
-                 auto_create_group On
+                 auto_create_group true
          ```
 
       1. Apply the manifest to your cluster\.


### PR DESCRIPTION
fix cloudwatch auto_create_group config

*Issue #, if available:*
auto_create_group config doesn't work

*Description of changes:*
I changed auto_create_group config config value for aws-logging-cloudwatch-configmap.yaml from On to True

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
