### PR TITLE
Update maximum size value

### DIFF
--- a/doc_source/update-managed-node-group.md
+++ b/doc_source/update-managed-node-group.md
@@ -101,7 +101,7 @@ You can modify some of the configurations of a managed node group\.
 
 1. \(Optional\) On the **Edit node group** page, edit the **Group size**\.
    + **Minimum size** – Specify the minimum number of nodes that the managed node group can scale in to\.
-   + **Maximum size** – Specify the maximum number of nodes that the managed node group can scale out to\. Managed node groups can support up to 100 nodes by default\.
+   + **Maximum size** – Specify the maximum number of nodes that the managed node group can scale out to\. Managed node groups can support up to 450 nodes by default\.
    + **Desired size** – Specify the current number of nodes that the managed node group should maintain\.
 
 1. When you're finished editing, choose **Save changes**\.


### PR DESCRIPTION
*Description of changes:*

The docs state that the maximum size of a managed node group is 100 nodes, but currently these limit is 450 nodes, as described in the EKS service quotas:
```
---------------------------------------------------------------------------
|                       ListAWSDefaultServiceQuotas                       |
+------------+--------------------------------------------------+---------+
|    Code    |                      Name                        |  Value  |
+------------+--------------------------------------------------+---------+
|  L-1194D53C|  Clusters                                        |  100.0  |
|  L-11427A54|  Control plane security groups per cluster       |  4.0    |
|  L-33415657|  Fargate profiles per cluster                    |  10.0   |
|  L-23414FF3|  Label pairs per Fargate profile selector        |  5.0    |
|  L-6D54EA21|  Managed node groups per cluster                 |  30.0   |
|  L-BD136A63|  Nodes per managed node group                    |  450.0  |
|  L-93A74D60|  Public endpoint access CIDR ranges per cluster  |  40.0   |
|  L-D78D8AF8|  Selectors per Fargate profile                   |  5.0    |
+------------+--------------------------------------------------+---------+
```