### PR TITLE
Correct the service quota for Fargate (service-quotas.md)

### DIFF
--- a/doc_source/service-quotas.md
+++ b/doc_source/service-quotas.md
@@ -67,4 +67,4 @@ The following quota is an Amazon EKS on AWS Fargate service quota\. The service 
 
 |  Service quota  |  Description  |  Default quota value  |  Adjustable  | 
 | --- | --- | --- | --- | 
-|  Fargate On\-Demand resource count  |  The maximum number of Amazon ECS tasks and Amazon EKS pods running concurrently on Fargate in this account in the current Region\.  |  500  | Yes | 
+|  Fargate On\-Demand resource count  |  The maximum number of Amazon ECS tasks and Amazon EKS pods running concurrently on Fargate in this account in the current Region\.  |  1,000  | Yes | 


### PR DESCRIPTION
I can see the maximum number of Amazon ECS tasks and Amazon EKS pods running concurrently on Fargate has been updated to 1,000 as mentioned in ECS Doc [1].

*Issue #, if available:*


I also can see the default limit for concurrent Fargate task can run per region is `10,000` via [Service Quota Console](https://console.aws.amazon.com/servicequotas/home):

![Screen Shot 2021-02-01 at 8 45 47 PM](https://user-images.githubusercontent.com/1008379/106460547-7c840700-64ce-11eb-83aa-04fd72690c39.png)

But the document still say it is `500` as default limit:

Service quota | Description | Default quota value | Adjustable
-- | -- | -- | --
Fargate On-Demand resource count | The maximum number of Amazon ECS tasks and Amazon EKS pods running concurrently on Fargate in this account in the current Region. | 500 | Yes

*Description of changes:*

So I am proposing the change to see if the document needs to be updated as right number of Fargate limit.

Reference:
- [1] https://docs.aws.amazon.com/AmazonECS/latest/developerguide/service-quotas.html#service-quotas-fargate

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.