### PR TITLE
add Kubernetes version support FAQ, fix a typo

### DIFF
--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -127,6 +127,9 @@ A: Amazon EKS is unable to provide specific timeframes\. Automatic updates can h
 **Q: Can I leave my control plane on a Kubernetes version indefinitely?**  
 A: No\. Cloud security at AWS is the highest priority\. Amazon EKS does not allow control planes to stay on a version that has reached end of support\.
 
+**Q: Which Kubernetes features are supported by Amazon EKS?**  
+A: Amazon EKS supports all GA features of the Kubernetes API, as well as Beta features which are enabled by default\. Alpha features are not supported\.
+
 **Q: Are Amazon EKS managed node groups automatically updated along with the cluster control plane version?**  
 A: No\. A managed node group creates Amazon EC2 instances in your account\. These instances aren't automatically upgraded when you or Amazon EKS update your control plane\. If Amazon EKS automatically updates your control plane, the Kubernetes version on your managed node group may be more than one version earlier than your control plane\. If a managed node group contains instances that are running a version of Kubernetes that is more than one version earlier than the control plane, the node group has a health issue in the **Node Groups** section of the **Compute** tab on the **Configuration** tab of your cluster in the console\. If a node group has an available version update, **Update now** appears next to the node group in the console\. For more information, see [Updating a managed node group](update-managed-node-group.md)\. We recommend maintaining the same Kubernetes version on your control plane and nodes\.
 

--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -121,7 +121,7 @@ A: Yes\. If any clusters in your account are running the version nearing the end
 **Q: What happens on the end of support date?**  
 A: On the end of support date, you are no longer able to create new Amazon EKS clusters with the unsupported version\. Existing control planes are automatically updated by Amazon EKS to the oldest supported version through a gradual deployment process after the end of support date\. After the automatic control plane update, you must manually update cluster add\-ons and Amazon EC2 nodes\. For more information, see [Update an existing cluster](update-cluster.md#update-existing-cluster)\.
 
-**Q: When exactly will my control planebe automatically updated after the end of support date?**  
+**Q: When exactly will my control plane be automatically updated after the end of support date?**  
 A: Amazon EKS is unable to provide specific timeframes\. Automatic updates can happen at any time after the end of support date\. We recommend that you take proactive action and update your control plane without relying on the Amazon EKS automatic update process\. For more information, see [Updating a cluster](update-cluster.md)\.
 
 **Q: Can I leave my control plane on a Kubernetes version indefinitely?**  


### PR DESCRIPTION
This PR adds an FAQ regading Kubernetes feature support to https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html

Also fix a typo in the same area.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
