### PR TITLE
add pod size note in fargate-pod-configuration.md

### DIFF
--- a/doc_source/fargate-pod-configuration.md
+++ b/doc_source/fargate-pod-configuration.md
@@ -27,7 +27,14 @@ The table below shows the vCPU and memory combinations that are available for po
 |  2 vCPU  |  Between 4 GB and 16 GB in 1\-GB increments  | 
 |  4 vCPU  |  Between 8 GB and 30 GB in 1\-GB increments  | 
 
-For pricing information on these compute configurations, see [AWS Fargate pricing](https://aws.amazon.com/fargate/pricing/)\.
+Note there is no correlation between the size of the pod running on Fargate and the node size as reported by Kubernetes with `kubectl get nodes`. The reported node size is often larger than the pod's capacity. To verify pod capacity, you can inspect the pod via `kubectl describe` or other means and refer to the `CapacityProvisioned` annotation. For example:
+
+```
+  annotations:
+    CapacityProvisioned: 0.25vCPU 0.5GB
+```
+
+The `CapacityProvisioned` annotation represents the enforced pod capacity and it determines the cost of your pod running on Fargate. For pricing information on these compute configurations, see [AWS Fargate pricing](https://aws.amazon.com/fargate/pricing/)\.
 
 ## Fargate storage<a name="fargate-storage"></a>
 


### PR DESCRIPTION
This PR adds a note in https://docs.aws.amazon.com/eks/latest/userguide/fargate-pod-configuration.html to make clear that Kubernetes node details are unrelated to Fargate pod size and capacity.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
