### PR TITLE
updates related to eksctl operations on non-eksctl clusters

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -59,7 +59,7 @@ Ensure that each Ingress in the same Ingress group has a unique priority number\
 
 You can run the sample application on a cluster that has Amazon EC2 nodes only, Fargate pods, or both\.
 
-1. If you're deploying to Fargate, create a Fargate profile\. If you're not deploying to Fargate skip this step\. The command that follows only works for clusters that were created with `eksctl`\. If you didn't create your cluster with `eksctl`, then you can create the profile with the the [AWS Management Console](fargate-profile.md#create-fargate-profile), using the same values for `name` and `namespace` that are in the command below\.
+1. If you're deploying to Fargate, create a Fargate profile\. If you're not deploying to Fargate skip this step\. You can invoke the following `eksctl` command, or you can create the profile with the the [AWS Management Console](fargate-profile.md#create-fargate-profile) using the same values for `name` and `namespace` that are in the command below\.
 
    ```
    eksctl create fargateprofile --cluster <my-cluster> --region <region-code> --name <alb-sample-app> --namespace game-2048

--- a/doc_source/create-service-account-iam-policy-and-role.md
+++ b/doc_source/create-service-account-iam-policy-and-role.md
@@ -72,9 +72,6 @@ Create an IAM role for your service account\. You can use [ `eksctl`](#create-se
 **To create your IAM role with `eksctl`**  
 Create the service account and IAM role with the following command\. Replace the `<example values>` \(including `<>`\) with your own values\.
 
-**Note**  
-This command only works for clusters that were created with `eksctl`\. If you didn't create your cluster with `eksctl`, then use the instructions on the AWS Management Console or AWS CLI tabs\.
-
 ```
 eksctl create iamserviceaccount \
     --name <service_account_name> \

--- a/doc_source/delete-cluster.md
+++ b/doc_source/delete-cluster.md
@@ -16,8 +16,6 @@ eksctl version
 ```
 
 For more information on installing or upgrading `eksctl`, see [Installing or upgrading `eksctl`](eksctl.md#installing-eksctl)\.
-**Note**  
-This procedure only works for clusters that were created with `eksctl`\.
 
 1. List all services running in your cluster\.
 

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -91,7 +91,7 @@ You may need to update some of your deployed resources before you can update to 
      eksctl version
      ```
 
-     For more information about installing or updating `eksctl`, see [Installing or upgrading `eksctl`](eksctl.md#installing-eksctl)\. You can only use `eksctl` to update a cluster that was created with `eksctl`\.
+     For more information about installing or updating `eksctl`, see [Installing or upgrading `eksctl`](eksctl.md#installing-eksctl)\.
 
      Update your Amazon EKS control plane's Kubernetes version one minor version later than its current version with the following command\. Replace `<my-cluster>` \(including `<>`\) with your cluster name\.
 

--- a/doc_source/windows-support.md
+++ b/doc_source/windows-support.md
@@ -19,7 +19,7 @@ The following steps help you to enable Windows support for your Amazon EKS clust
 
 **To enable Windows support for your cluster with `eksctl`**
 
-This procedure only works for clusters that were created with `eksctl` and assumes that your `eksctl` version is `0.37.0` or later\. You can check your version with the following command\.
+This procedure assumes that your `eksctl` version is `0.37.0` or later\. You can check your version with the following command\.
 
 ```
 eksctl version


### PR DESCRIPTION
This is a small set of changes tracking upstream work which allows eksctl to operate on clusters which it didn't create.

These changes remove for certain operations the note which indicates eksctl must have created the cluster. These are now supported for all EKS clusters.

This ongoing work is being tracked in https://github.com/weaveworks/eksctl/issues/2174. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
