### PR TITLE
Update fargate.md

### DIFF
--- a/doc_source/fargate.md
+++ b/doc_source/fargate.md
@@ -33,6 +33,7 @@ AWS Fargate with Amazon EKS is currently available in the following Regions:
 | Europe \(London\) | eu\-west\-2 | 
 | Europe \(Paris\) | eu\-west\-3 | 
 | Europe \(Stockholm\) | eu\-north\-1 | 
+| Europe \(Milan\) | eu\-south\-1 | 
 | South America \(São Paulo\) | sa\-east\-1 | 
 | Middle East \(Bahrain\) | me\-south\-1 | 
 


### PR DESCRIPTION
Adding Milan eu-south-1 as supported region for EKS Fargate https://aws.amazon.com/about-aws/whats-new/2020/08/amazon-eks-now-available-cape-town-milan/

*Issue #, if available:* doc not reporting Milan as supported region for EKS Fargate

*Description of changes:* updated doc adding eu-south-1 to the table listing supported regions


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
