### PR TITLE
Kube-proxy 1.19.6 use eksbuild.2 tag suffix

### DIFF
--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -201,7 +201,7 @@ You may need to update some of your deployed resources before you can update to 
       ```
       kubectl set image daemonset.apps/kube-proxy \
         -n kube-system \
-        kube-proxy=<602401143452.dkr.ecr.us-west-2.amazonaws.com>/eks/kube-proxy:v<1.19.6>-eksbuild.1
+        kube-proxy=<602401143452.dkr.ecr.us-west-2.amazonaws.com>/eks/kube-proxy:v<1.19.6>-eksbuild.2
       ```
 
       Your account ID and Region may differ from the example above\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Modify the eksbuild tag suffix to `eksbuild.2` for kube-proxy v1.19.6.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
