### PR TITLE
Include csr expiration information - windows-support.md

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -26,7 +26,8 @@ Before deploying security groups for pods, consider the following limits and con
       name: eks-vpc-resource-controller
   ```
 + If you're using [custom networking](cni-custom-network.md) and security groups for pods together, the security group specified by security groups for pods is used instead of the security group specified in the `ENIconfig`\.
-+ Pods using security groups must contain `terminationGracePeriodInSeconds` in their pod spec\. This is because the Amazon EKS VPC CNI plugin queries the API server to retrieve the pod IP address before deleting the pod network on the host\. Without this setting, the plugin doesn't remove the pod network on the host\. 
++ Pods using security groups must contain `terminationGracePeriodInSeconds` in their pod spec\. This is because the Amazon EKS VPC CNI plugin queries the API server to retrieve the pod IP address before deleting the pod network on the host\. Without this setting, the plugin doesn't remove the pod network on the host\.
++ Pods using Security Groups are not supported in clusters using [Nodelocal DNSCache](https://kubernetes.io/docs/tasks/administer-cluster/nodelocaldns/).
 
 ## Deploy security groups for pods<a name="security-groups-pods-deployment"></a>
 


### PR DESCRIPTION
The length of duration signed certificates will be given is based on the flag set for the kube-controller-manager '--cluster-signing-duration duration' [1] - if this is not set (as we keep this as the default for EKS, you can check the arguments we do pass via the kube-controller-manager logs if logging is enabled in the cluster) then the cluster will use the default setting of 8760h0m0s (1 year) [2]. We do not include this information in the documentation, these changes indicate how to:
 + Provide information as to the default setting used in EKS
 + Determine the expiry date at the time of the cert creation
 + Steps to rotate an expired certificate.

Ref: 
[1] Kubernetes signers - https://kubernetes.io/docs/reference/access-authn-authz/certificate-signing-requests/#kubernetes-signers
[2] csrsigningcontroller.go - https://github.com/kubernetes/kubernetes/cmd/kube-controller-manager/app/options/csrsigningcontroller.go#L48

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
