### PR TITLE
updated stale config for cluster autoscaler - priority -> priorities

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -365,7 +365,7 @@ metadata:
   name: cluster-autoscaler-priority-expander
   namespace: kube-system
 data:
-  priority: |-
+  priorities: |-
     10:
       - .*p2-node-group.*
     50:


### PR DESCRIPTION
I0220 15:27:25.416953       1 event.go:278] Event(v1.ObjectReference{Kind:"ConfigMap", Namespace:"kube-system", Name:"cluster-autoscaler-priority-expander", UID:"052af77f-725a-453a-ae2c-8873d3b3ede1", APIVersion:"v1", ResourceVersion:"827024", FieldPath:""}): type: 'Warning' reason: 'PriorityConfigMapInvalid' Wrong configmap for priority expander, doesn't contain priorities key. Ignoring update.

*Issue #, if available:*

Cluster autoscaler fails with following error when `data.priority` property is provided for Priority Expander configMap.

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-autoscaler-priority-expander
  namespace: kube-system
data:
  priority: |-  # <<<----THIS IS BROKEN
    10:
      - .*eks-ng1*
    50:
      - .*eks-ng2*
```

- Error:
```
I0220 15:27:25.416953       1 event.go:278] Event(v1.ObjectReference{Kind:"ConfigMap", Namespace:"kube-system", Name:"cluster-autoscaler-priority-expander", UID:"052af77f-725a-453a-ae2c-8873d3b3ede1", APIVersion:"v1", ResourceVersion:"827024", FieldPath:""}): type: 'Warning' reason: 'PriorityConfigMapInvalid' Wrong configmap for priority expander, doesn't contain priorities key. Ignoring update.
```

*Description of changes:*
- Fix is to use `data.priorities`

```
apiVersion: v1
kind: ConfigMap
metadata:
  name: cluster-autoscaler-priority-expander
  namespace: kube-system
data:
  priorities: |-  # <<---THIS WORKS
    10:
      - .*ng1*
    50:
      - .*ng2*
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
