### PR TITLE
Fixes reference to nodegroup CFN template yaml

### DIFF
--- a/doc_source/launch-workers.md
+++ b/doc_source/launch-workers.md
@@ -67,7 +67,7 @@ This procedure has the following prerequisites:
 1. Download the latest version of the AWS CloudFormation template\.
 
    ```
-   curl -o amazon-eks-nodegroup.yaml https://github.com/awslabs/amazon-eks-ami/blob/master/amazon-eks-nodegroup.yaml
+   curl -o amazon-eks-nodegroup.yaml https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/amazon-eks-nodegroup.yaml
    ```
 
 1. Open the AWS CloudFormation console at [https://console\.aws\.amazon\.com/cloudformation](https://console.aws.amazon.com/cloudformation/)\.


### PR DESCRIPTION
*Issue #, if available:*

[AMI issue](https://github.com/awslabs/amazon-eks-ami/issues/621)

*Description of changes:*

The current guidance fails with a `Template format error: YAML not well-formed` because it downloads the HTML page, not the actual yaml. If we link to the GitHub raw link, it works for me.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
