### PR TITLE
Fixed Invalid Prometheus Chart

### DIFF
--- a/doc_source/prometheus.md
+++ b/doc_source/prometheus.md
@@ -56,7 +56,7 @@ After you configure Helm for your Amazon EKS cluster, you can use it to deploy P
 1. Add the `prometheus-community` chart repository\.
 
    ```
-   helm repo add prometheus-community https://github.com/prometheus-community/helm-charts
+   helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
    ```
 
 1. Deploy Prometheus\.


### PR DESCRIPTION
Fixing the error:

helm repo add prometheus-community https://github.com/prometheus-community/helm-charts
Error: looks like "https://github.com/prometheus-community/helm-charts" is not a valid chart repository or cannot be reached: failed to fetch https://github.com/prometheus-community/helm-charts/index.yaml : 404 Not Found