### PR TITLE
Outdated instructions in coredns.md

### DIFF
--- a/doc_source/coredns.md
+++ b/doc_source/coredns.md
@@ -124,7 +124,7 @@ You must complete this before upgrading to CoreDNS version `1.7.0`, but it's rec
    1. Check to see if your CoreDNS manifest has the line\.
 
       ```
-      kubectl get configmap coredns -n kube-system -o yaml |grep upstream
+      kubectl get configmap coredns -n kube-system -o jsonpath='{$.data.Corefile}' | grep upstream
       ```
 
       If no output is returned, your manifest doesn't have the line and you can skip to the next step to update CoreDNS\. If output is returned, then you need to remove the line\.

--- a/doc_source/update-cluster.md
+++ b/doc_source/update-cluster.md
@@ -271,7 +271,7 @@ You may need to update some of your deployed resources before you can update to 
    kubectl get deployment coredns --namespace kube-system -o=jsonpath='{$.spec.template.spec.containers[:1].image}'
    ```
 
-1. Update `coredns` to the recommended version by taking the output from the previous step and replacing *`<1.8.0>`* \(including *`<>`*\) with your cluster's recommended `coredns` version:
+1. Update `coredns` to the recommended version by replacing the *account ID* and *Region* using the output from the previous step and and replacing *`<1.8.0>`* \(including *`<>`*\) with your cluster's recommended `coredns` version:
 
    ```
    kubectl set image --namespace kube-system deployment.apps/coredns \


### PR DESCRIPTION
*Description of changes:*
[coredns.md](https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/coredns.md) does not match [update-cluster.md](https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/update-cluster.md) where it should. This PR updates coredns.md in alignment with https://github.com/awsdocs/amazon-eks-user-guide/pull/223


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.