### PR TITLE
[Discrepancy on EKS documentation] Creating a Fargate profile via AWS Console

### DIFF
--- a/doc_source/fargate-getting-started.md
+++ b/doc_source/fargate-getting-started.md
@@ -77,25 +77,34 @@ Create your Fargate profile with the following `eksctl` command, replacing the *
 ```
 eksctl create fargateprofile --cluster <cluster_name> --name <fargate_profile_name> --namespace <kubernetes_namespace> --labels <key=value>
 ```
-
 ------
-#### [ AWS Management Console ]
+#### [ AWS Management Console ]<a name="create-fargate-profile-console"></a>
 
-**To create an AWS Fargate pod execution role with the AWS Management Console**
+**To create a Fargate profile for a cluster with the AWS Management Console**
 
-1. Open the IAM console at [https://console\.aws\.amazon\.com/iam/](https://console.aws.amazon.com/iam/)\.
+1. Open the Amazon EKS console at [https://console\.aws\.amazon\.com/eks/home\#/clusters](https://console.aws.amazon.com/eks/home#/clusters)\.
 
-1. Choose **Roles**, then **Create role**\.
+1. Choose the cluster to create a Fargate profile for\.
 
-1. Choose **EKS** from the list of services, **EKS \- Fargate pod** for your use case, and then **Next: Permissions**\.
+1. Under **Fargate profiles**, choose **Add Fargate profile**\.
 
-1. Choose **Next: Tags**\.
+1. On the **Configure Fargate profile** page, enter the following information and choose **Next**\.
 
-1. \(Optional\) Add metadata to the role by attaching tags as key–value pairs\. For more information about using tags in IAM, see [Tagging IAM Entities](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_tags.html) in the *IAM User Guide*\. 
+   1. For **Name**, enter a unique name for your Fargate profile\.
 
-1. Choose **Next: Review**\.
+   1. For **Pod execution role**, choose the pod execution role to use with your Fargate profile\. Only IAM roles with the `eks-fargate-pods.amazonaws.com` service principal are shown\. If you do not see any roles listed here, you must create one\. For more information, see [Pod execution role](pod-execution-role.md)\.
 
-1. For **Role name**, enter a unique name for your role, such as `AmazonEKSFargatePodExecutionRole`, then choose **Create role**\.
+   1. For **Subnets**, choose the subnets to use for your pods\. By default, all subnets in your cluster's VPC are selected\. Only private subnets are supported for pods running on Fargate; you must deselect any public subnets\.
+
+   1. For **Tags**, you can optionally tag your Fargate profile\. These tags do not propagate to other resources associated with the profile, such as its pods\.
+
+1. On the **Configure pods selection** page, enter the following information and choose **Next**\.
+
+   1. For **Namespace**, enter a namespace to match for pods, such as `kube-system` or `default`\.
+
+   1. \(Optional\) Add Kubernetes labels to the selector that pods in the specified namespace must have to match the selector\. For example, you could add the label `infrastructure: fargate` to the selector so that only pods in the specified namespace that also have the `infrastructure: fargate` Kubernetes label match the selector\.
+
+1. On the **Review and create** page, review the information for your Fargate profile and choose **Create**\.
 
 ------
 


### PR DESCRIPTION
We noticed the steps provided here for the creation of a Fargate profile via AWS Console are not correct, they directly point to "To create an AWS Fargate pod execution role with the AWS Management Console", instead the steps to create the Fargate profile.

Here we can see the instruction to create the Fargate profile with eksctl, however in the tab for "AWS Management Console", the steps are for the creation of the AWS Fargate pod execution role:

--- Getting started with AWS Fargate using Amazon EKS - Create a Fargate profile for your cluster - https://docs.aws.amazon.com/eks/latest/userguide/fargate-getting-started.html#fargate-gs-create-profile
--- https://github.com/awsdocs/amazon-eks-user-guide/blob/master/doc_source/fargate-getting-started.md#create-a-fargate-profile-for-your-cluster

Here is the only place I found properly detailed how to create the Fargate Profile via AWS Console besides eksctl:
--- AWS Fargate profile - Creating a Fargate profile - https://docs.aws.amazon.com/eks/latest/userguide/fargate-profile.html#create-fargate-profile

Could we review this to avoid any confusions?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
