### PR TITLE
Update update-managed-node-group.md

### DIFF
--- a/doc_source/update-managed-node-group.md
+++ b/doc_source/update-managed-node-group.md
@@ -64,12 +64,6 @@ You can't directly upgrade a node group that's deployed without a launch templat
    + **Rolling update** – This option respects the pod disruption budgets for your cluster\. Updates fail if there is a pod disruption budget issue that causes Amazon EKS to be unable to gracefully drain the pods that are running on this node group\.
    + **Force update** – This option doesn't respect pod disruption budgets\. Updates occur regardless of pod disruption budget issues by forcing node restarts to occur\.
 
-1. \(Optional\) If you use the Kubernetes [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler), scale the deployment back to your desired number of replicas\.
-
-   ```
-   kubectl scale deployments/cluster-autoscaler --replicas=<1> -n kube-system
-   ```
-
 ------
 
 ## Edit a node group configuration<a name="mng-edit"></a>

--- a/doc_source/update-managed-node-group.md
+++ b/doc_source/update-managed-node-group.md
@@ -12,9 +12,6 @@ There are several scenarios where it's useful to update your Amazon EKS managed 
 
 If there's a newer AMI release version for your managed node group's Kubernetes version, you can update your node group's version to use the newer AMI version\. Similarly, if your cluster is running a Kubernetes version that's newer than your node group, you can update the node group to use the latest AMI release version to match your cluster's Kubernetes version\.
 
-**Note**  
-You can't roll back a node group to an earlier Kubernetes version or AMI version\.
-
 When a node in a managed node group is terminated due to a scaling action or update, the pods in that node are drained first\. For more information, see [Managed node update behavior](managed-node-update-behavior.md)\.
 
 ## Update a node group version<a name="mng-update"></a>
@@ -39,12 +36,6 @@ You can't directly upgrade a node group that's deployed without a launch templat
 
    ```
    eksctl upgrade nodegroup --name=<node-group-name> --cluster=<cluster-name> --kubernetes-version=<1.19>
-   ```
-
-1. \(Optional\) If you use the Kubernetes [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler), scale the deployment back to your desired number of replicas\.
-
-   ```
-   kubectl scale deployments/cluster-autoscaler --replicas=<1> -n kube-system
    ```
 
 ------


### PR DESCRIPTION
Removing note that stated AMIs couldn't be rolled back, and that Cluster Autoscaler was needed to be scaled to zero.

*Issue #, if available:* N/A

*Description of changes:*
Updating documentation following feature change on Managed Nodegroups that permits rolling back the release version of a nodegroup. Also removing the recommendation of CAS needing to be scaled to zero as per https://github.com/aws/containers-roadmap/issues/916#issuecomment-755449543

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
