### PR TITLE
added note on connection issues for secondary cidr expansion

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -14,6 +14,9 @@ The procedure in this topic instructs the CNI plugin to associate different secu
 
 1. Associate a secondary CIDR block to your cluster's VPC\. For more information, see [Associating a Secondary IPv4 CIDR Block with Your VPC](https://docs.aws.amazon.com/vpc/latest/userguide/working-with-vpcs.html#add-ipv4-cidr) in the *Amazon VPC User Guide*\.
 
+    **Note**: 
+    - Adding a Secondary CIDR to Amazon VPC will update VPC route tables on your AWS Account but do not cause updates on the EKS Control Plane route tables. This will cause connection timeouts from EKS Control Plane to worker nodes and Pods with Secondary VPC CIDR IP range.
+    - Please go through Github issue comment [710225610](https://github.com/aws/containers-roadmap/issues/170#issuecomment-710225610) for workaround or reach out to AWS Premium Support.
 1. Create a subnet in your VPC for each Availability Zone, using your secondary CIDR block\. Your custom subnets must be from a different VPC CIDR block than the subnet that your nodes were launched into\. For more information, see [Creating a subnet in your VPC ](https://docs.aws.amazon.com/vpc/latest/userguide/working-with-vpcs.html#AddaSubnet) in the *Amazon VPC User Guide*\.
 
 1. Set the `AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG` environment variable to `true` in the `aws-node` DaemonSet:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Post adding additional CIDR to a VPC, there will be network issues from EKS Control Plane to worker nodes/pods deployed on secondary CIDR IP Range.
- - Updated AWS VPC CNI Custom Networking documentation with a note

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
