### PR TITLE
Added more clarity on restarting the ebsci controller deployments, ra…

### DIFF
--- a/doc_source/ebs-csi.md
+++ b/doc_source/ebs-csi.md
@@ -153,12 +153,12 @@ To see or download the `yaml` file manually, you can find it on the [aws\-ebs\-c
      eks.amazonaws.com/role-arn=arn:aws:iam::<AWS_ACCOUNT_ID>:role/AmazonEKS_EBS_CSI_DriverRole
    ```
 
-1. Delete the driver pods\. They're automatically redeployed with the IAM permissions from the IAM policy assigned to the role\.
+1. Restart the ebs-csi-controller deployment.
 
    ```
-   kubectl delete pods \
-     -n kube-system \
-     -l=app=ebs-csi-controller
+   kubectl rollout restart \
+   deployment ebs-csi-controller \
+   -n kube-system
    ```
 
 **To deploy a sample application and verify that the CSI driver is working**


### PR DESCRIPTION
…ther than deleting the controller pods

*Issue #, if available:*

*Description of changes:*

The message in the documentation is somewhat misleading to people, sometimes they may choose to ignore deleting the pods, hence instead of deleting the pods, we've changed it to restart of the ebs-csi-controller deployment.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
