### PR TITLE
Add a note to ensure the min or recommended security group settings are

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -135,5 +135,7 @@ Ensure that an annotation with the key `k8s.amazonaws.com/eniConfig` for the `EN
      - <sg-0dff222a2d22c2c22>
      subnet: <subnet-022b222c2f22fdf22>
    ```
+**Note**
+If you want to continue with the existing configuration and use the security group from step 6, ensure that the recommended or minimum required security group settings for the cluster, control plane and node security groups are met. For more information, see [Amazon EKS security group considerations](sec-group-reqs.md)\.
 
 1. If you had any nodes in your cluster with running Pods before you switched to the custom CNI networking feature, you should cordon and drain the nodes to gracefully shutdown the Pods and then terminate the nodes\. Only new nodes that are registered with the `k8s.amazonaws.com/eniConfig` label use the custom networking feature\.


### PR DESCRIPTION
met if using a custom security group in ENIConfig

*Issue #, if available:* 350

*Description of changes:*
Add a note linking https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html to ensure that the min or recommended security group settings are met when using a custom security group in the ENIConfig instead of node group security group. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
