### PR TITLE
Kubernetes tools v1.18.16 are no longer available

### DIFF
--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -23,7 +23,7 @@ Select the tab with the name of the operating system that you want to install `k
    + **Kubernetes 1\.18:**
 
      ```
-     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/darwin/amd64/kubectl
+     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/darwin/amd64/kubectl
      ```
    + **Kubernetes 1\.17:**
 
@@ -47,7 +47,7 @@ Select the tab with the name of the operating system that you want to install `k
       + **Kubernetes 1\.18:**
 
         ```
-        curl -o kubectl.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/darwin/amd64/kubectl.sha256
+        curl -o kubectl.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/darwin/amd64/kubectl.sha256
         ```
       + **Kubernetes 1\.17:**
 
@@ -106,7 +106,7 @@ Select the tab with the name of the operating system that you want to install `k
    + **Kubernetes 1\.18:**
 
      ```
-     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/linux/amd64/kubectl
+     curl -o kubectl https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/kubectl
      ```
    + **Kubernetes 1\.17:**
 
@@ -130,7 +130,7 @@ Select the tab with the name of the operating system that you want to install `k
       + **Kubernetes 1\.18:**
 
         ```
-        curl -o kubectl.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/linux/amd64/kubectl.sha256
+        curl -o kubectl.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/linux/amd64/kubectl.sha256
         ```
       + **Kubernetes 1\.17:**
 
@@ -193,7 +193,7 @@ This step assumes you are using the Bash shell; if you are using another shell, 
    + **Kubernetes 1\.18:**
 
      ```
-     curl -o kubectl.exe https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/windows/amd64/kubectl.exe
+     curl -o kubectl.exe https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/windows/amd64/kubectl.exe
      ```
    + **Kubernetes 1\.17:**
 
@@ -217,7 +217,7 @@ This step assumes you are using the Bash shell; if you are using another shell, 
       + **Kubernetes 1\.18:**
 
         ```
-        curl -o kubectl.exe.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.16/2020-11-02/bin/windows/amd64/kubectl.exe.sha256
+        curl -o kubectl.exe.sha256 https://amazon-eks.s3.us-west-2.amazonaws.com/1.18.9/2020-11-02/bin/windows/amd64/kubectl.exe.sha256
         ```
       + **Kubernetes 1\.17:**
 


### PR DESCRIPTION
Looking at the S3 bucket contents, version 1.18.9 is now the latest available.

*Issue #, if available:*
N/A

*Description of changes:*
Updated tools version number from 1.18.16 to 1.18.9 which is actually available for download.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
