### PR TITLE
Update security-groups-for-pods.md for revising the sentence regarding security group

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -105,7 +105,7 @@ The trunk network interface is included in the maximum number of network interfa
 **Important**  
 The security groups that you specify in the policy must exist\. If they don't exist, then, when you deploy a pod that matches the selector, your pod remains stuck in the creation process\. If you describe the pod, you'll see an error message similar to the following one: `An error occurred (InvalidSecurityGroupID.NotFound) when calling the CreateNetworkInterface operation: The securityGroup ID '<sg-abc123>' does not exist`\.
 The security group must allow inbound communication from the cluster security group \(for `kubelet`\) over any ports you've configured probes for\.
-The security group must allow outbound communication to the cluster security group \(for CoreDNS\) over TCP and UDP port 53\. The cluster security group must also allow inbound TCP and UDP port 53 communication from all security groups associated to pods\.
+The security group must allow outbound communication to the Node Group security group \(for CoreDNS\) over TCP and UDP port 53\. The Node Group security group must also allow inbound TCP and UDP port 53 communication from all security groups associated to pods\.
 
    1. Deploy the policy\.
 


### PR DESCRIPTION
*Issue #, if available:*

I think the statement of documentation is mislead. Allowing port 53 for TCP/UDP of cluster security group is not general applicable for affecting the CoreDNS resolution in every environment, unless the security group policy is associating with cluster security group by referring to the following the blog post:

> The first security group we want to apply is the EKS cluster security group, which enables the matched pods launched onto branch network interfaces to communicate with other pods in the cluster such as CoreDNS

- https://aws.amazon.com/tw/blogs/containers/introducing-security-groups-for-pods/

In the EKS workshop, it is associating the Node Group security group accordingly instead of using cluster security group:

- https://www.eksworkshop.com/beginner/115_sg-per-pod/10_secgroup/

*Description of changes:*

So I would like to propose the change by using `Node Group security group`. It would be great if the doc can revise the sentence to make sure it can meet most of scenarios to allow CoreDNS resolution when setting the security group for Pod.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
