### PR TITLE
Update launch-node-bottlerocket.md

### DIFF
--- a/doc_source/launch-node-bottlerocket.md
+++ b/doc_source/launch-node-bottlerocket.md
@@ -14,6 +14,9 @@ There is no AWS CloudFormation template to deploy nodes with\.
 **Important**  
 Do not use `eksctl` to create a cluster or nodes in an AWS Region where you have AWS Outposts, AWS Wavelength, or AWS Local Zones enabled\. Create a cluster and self\-managed nodes using the Amazon EC2 API or AWS CloudFormation instead\. For more information, see [Launching self\-managed Amazon Linux nodes](launch-workers.md) and [Launching self\-managed Windows nodes](launch-windows-workers.md)\.
 
+**Important**  
+Be aware that [there is no SSH server in a Bottlerocket image, and not even a shell](https://github.com/bottlerocket-os/bottlerocket/blob/develop/README.md#exploration). Out-of-band modifications are needed in order to allow SSH enabling the [admin container](https://github.com/bottlerocket-os/bottlerocket#admin-container), which is disabled by deafult, and pass some [bootstrapping configuration steps](https://github.com/bottlerocket-os/bottlerocket#kubernetes-settings) via UserData.
+
 **To launch Bottlerocket nodes using `eksctl`**
 
 This procedure requires `eksctl` version `0.39.0` or later\. You can check your version with the following command:


### PR DESCRIPTION
Update launch-node-bottlerocket.md since documentation is incomplete, confusing and unclear regarding how to SSH to Bottlerocket Nodes.

*Issue #, if available:*
Currently the documentation completely ignores this important point about how to perform SSH. [Here](https://github.com/bottlerocket-os/bottlerocket/blob/develop/QUICKSTART-EKS.md#using-a-bottlerocket-ami-with-amazon-eks) is just mentioned "for test clusters where you know you'll want SSH access. Make sure to change the publicKeyName setting to the name of the SSH keypair you have registered with EC2.". 

*Description of changes:*
However, since there's no SSH server in a Bottlerocket image, and not even a shell, is necessary to do some out-of-band modifications using the admin container which is disabled by default, passing some bootstrapping steps via UserData.

This lack of information make it confusing for people who is new trying to use Bottlerocket and EKS. This is an important point should be highlighted in the documentation, since doing SSH is something vital you would like to do in your applications. 

I basically added the following as an Important Note which will help us and save valuable time pointing this out from the beginning: 

**Important**  
Be aware that [there is no SSH server in a Bottlerocket image, and not even a shell](https://github.com/bottlerocket-os/bottlerocket/blob/develop/README.md#exploration). Out-of-band modifications are needed in order to allow SSH enabling the [admin container](https://github.com/bottlerocket-os/bottlerocket#admin-container), which is disabled by deafult, and pass some [bootstrapping configuration steps](https://github.com/bottlerocket-os/bottlerocket#kubernetes-settings) via UserData.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
