### PR TITLE
Account ID variable renamed

### DIFF
--- a/doc_source/create-service-account-iam-policy-and-role.md
+++ b/doc_source/create-service-account-iam-policy-and-role.md
@@ -166,7 +166,7 @@ You must use at least version 1\.19\.7 or 2\.1\.26 of the AWS CLI to receive the
        {
          "Effect": "Allow",
          "Principal": {
-           "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
+           "Federated": "arn:aws:iam::${ACCOUNT_ID}:oidc-provider/${OIDC_PROVIDER}"
          },
          "Action": "sts:AssumeRoleWithWebIdentity",
          "Condition": {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Hello,
The Account ID variable exported at step 1 is different from the variable is used to create the trust policy (on step 3).

When running the command to generate the JSON file, the account id field is empty.

Example:

![](https://i.imgur.com/bAOj7rP.png)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
