### PR TITLE
Update managing-coredns.md

### DIFF
--- a/doc_source/managing-coredns.md
+++ b/doc_source/managing-coredns.md
@@ -232,7 +232,7 @@ You must complete this before upgrading to CoreDNS version `1.7.0`, but it's rec
    ```
    ...
    - apiGroups:
-     - discover.k8s.io
+     - discovery.k8s.io
      resources:
      - endpointslices
      verbs:


### PR DESCRIPTION
Fixed wrong apiGroups name causing errors in coredns pod after upgrade to 1.8.3

`E0521 15:40:26.038658       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.2/tools/cache/reflector.go:167: Failed to watch *v1beta1.EndpointSlice: failed to list *v1beta1.EndpointSlice: endpointslices.discovery.k8s.io is forbidden: User "system:serviceaccount:kube-system:coredns" cannot list resource "endpointslices" in API group "discovery.k8s.io" at the cluster scope`

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
