### PR TITLE
Clarify manual add-on management vs EKS add-ons

### DIFF
--- a/doc_source/managing-coredns.md
+++ b/doc_source/managing-coredns.md
@@ -15,7 +15,7 @@ If you have a 1\.18 or later cluster that you have not added the CoreDNS Amazon 
 
 If you've added the CoreDNS Amazon EKS add\-on to your 1\.18 or later cluster, you can manage it using the procedures in the [Updating the CoreDNS Amazon EKS add\-on](#updating-coredns-eks-add-on) and [Removing the CoreDNS Amazon EKS add\-on](#removing-coredns-eks-add-on) sections\. For more information about Amazon EKS add\-ons, see [Amazon EKS add\-ons](eks-add-ons.md)\.
 
-If you have not added the CoreDNS Amazon EKS add\-on, the add\-on is still running on your cluster\. You can manually update the CoreDNS add\-on using the procedure in the [Updating the CoreDNS add\-on](#updating-coredns-add-on) section\.
+If you have not added the CoreDNS Amazon EKS add\-on, the add\-on is still running on your cluster\. You can manually update the CoreDNS add\-on using the procedure in the [Updating the CoreDNS add\-on manually](#updating-coredns-add-on) section\.
 
 ## Adding the CoreDNS Amazon EKS add\-on<a name="adding-coredns-eks-add-on"></a>
 
@@ -59,7 +59,7 @@ If you want the add\-on to overwrite any changes you've made to the add\-on with
 
 ## Updating the CoreDNS Amazon EKS add\-on<a name="updating-coredns-eks-add-on"></a>
 
-This procedure is for updating the CoreDNS Amazon EKS add\-on\. If you haven't added the CoreDNS Amazon EKS add\-on, complete the procedure in [Updating the CoreDNS add\-on](#updating-coredns-add-on) instead, or [add the CoreDNS Amazon EKS add\-on](#adding-coredns-eks-add-on)\. Amazon EKS does not automatically update CoreDNS on your cluster when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update CoreDNS on an existing cluster, you must initiate the update and then Amazon EKS updates the Amazon EKS add\-on for you\. 
+This procedure is for updating the CoreDNS Amazon EKS add\-on\. If you haven't added the CoreDNS Amazon EKS add\-on, complete the procedure in [Updating the CoreDNS add\-on manually](#updating-coredns-add-on) instead, or [add the CoreDNS Amazon EKS add\-on](#adding-coredns-eks-add-on)\. Amazon EKS does not automatically update CoreDNS on your cluster when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update CoreDNS on an existing cluster, you must initiate the update and then Amazon EKS updates the Amazon EKS add\-on for you\. 
 
 ------
 #### [ AWS Management Console ]
@@ -162,9 +162,9 @@ aws eks delete-addon --cluster-name my-cluster --addon-name coredns
 
 ------
 
-## Updating the CoreDNS add\-on<a name="updating-coredns-add-on"></a>
+## Updating the CoreDNS add\-on manually<a name="updating-coredns-add-on"></a>
 
-If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the CoreDNS Amazon EKS add\-on to, complete the following steps to update the add\-on\. If you've added the CoreDNS Amazon EKS add\-on, complete the procedure in [Updating the CoreDNS Amazon EKS add\-on](#updating-coredns-eks-add-on) instead\.
+If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the CoreDNS Amazon EKS add\-on to, complete the following steps to update the add\-on manually\. If you've added the CoreDNS Amazon EKS add\-on, complete the procedure in [Updating the CoreDNS Amazon EKS add\-on](#updating-coredns-eks-add-on) instead\.
 
 **To update the CoreDNS add\-on**
 

--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -15,7 +15,7 @@ If you have a 1\.18 or later cluster that you have not added the `kube-proxy` Am
 
 If you've added the `kube-proxy` Amazon EKS add\-on to your 1\.18 or later cluster, you can manage it using the procedures in the [Updating the `kube-proxy` Amazon EKS add\-on](#updating-kube-proxy-eks-add-on) and [Removing the `kube-proxy` Amazon EKS add\-on](#removing-kube-proxy-eks-add-on) sections\. For more information about Amazon EKS add\-ons, see [Amazon EKS add\-ons](eks-add-ons.md)\.
 
-If you have not added the `kube-proxy` Amazon EKS add\-on, the `kube-proxy` add\-on is still running on your cluster\. You can manually update the `kube-proxy` add\-on using the procedure in the [Updating the `kube-proxy` add\-on](#updating-kube-proxy-add-on) section\.
+If you have not added the `kube-proxy` Amazon EKS add\-on, the `kube-proxy` add\-on is still running on your cluster\. You can manually update the `kube-proxy` add\-on using the procedure in the [Updating the `kube-proxy` add\-on manually](#updating-kube-proxy-add-on) section\.
 
 ## Adding the `kube-proxy` Amazon EKS add\-on<a name="adding-kube-proxy-eks-add-on"></a>
 
@@ -57,7 +57,7 @@ If you want the add\-on to overwrite any changes you've made to the add\-on with
 
 ## Updating the `kube-proxy` Amazon EKS add\-on<a name="updating-kube-proxy-eks-add-on"></a>
 
-This procedure is for updating the `kube-proxy` Amazon EKS add\-on\. If you haven't added the `kube-proxy` Amazon EKS add\-on, complete the procedure in [Updating the `kube-proxy` add\-on](#updating-kube-proxy-add-on) instead\. Amazon EKS does not automatically update `kube-proxy` on your cluster when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update `kube-proxy` on an existing cluster, you must initiate the update and then Amazon EKS updates the add\-on for you\. 
+This procedure is for updating the `kube-proxy` Amazon EKS add\-on\. If you haven't added the `kube-proxy` Amazon EKS add\-on, complete the procedure in [Updating the `kube-proxy` add\-on manually](#updating-kube-proxy-add-on) instead\. Amazon EKS does not automatically update `kube-proxy` on your cluster when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update `kube-proxy` on an existing cluster, you must initiate the update and then Amazon EKS updates the add\-on for you\. 
 
 **Important**  
 `Kube-proxy` is backward, but not forward compatible with `kubelet`\. You should update your cluster and nodes before updating `kube-proxy` to a new version\.
@@ -163,9 +163,9 @@ aws eks delete-addon --cluster-name my-cluster --addon-name kube-proxy
 
 ------
 
-## Updating the `kube-proxy` add\-on<a name="updating-kube-proxy-add-on"></a>
+## Updating the `kube-proxy` add\-on manually<a name="updating-kube-proxy-add-on"></a>
 
-If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the `kube-proxy` Amazon EKS add\-on to, complete the following steps to update the add\-on\. If you've added the `kube-proxy` Amazon EKS add\-on, complete the procedure in [Updating the `kube-proxy` Amazon EKS add\-on](#updating-kube-proxy-eks-add-on) instead\.
+If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the `kube-proxy` Amazon EKS add\-on to, complete the following steps to update the add\-on manually\. If you've added the `kube-proxy` Amazon EKS add\-on, complete the procedure in [Updating the `kube-proxy` Amazon EKS add\-on](#updating-kube-proxy-eks-add-on) instead\.
 
 **Important**  
 `Kube-proxy` is backward, but not forward compatible with `kubelet`\. You should update your cluster and nodes before updating `kube-proxy` to a new version\.

--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -15,7 +15,7 @@ If you have a 1\.18 or later cluster that you have not added the VPC CNI Amazon 
 
 If you've added the Amazon VPC CNI Amazon EKS add\-on to your 1\.18 or later with eks\.3 platform version or later cluster, you can manage it using the procedures in the [Updating the Amazon VPC CNI Amazon EKS add\-on](#updating-vpc-cni-eks-add-on) and [Removing the Amazon VPC CNI Amazon EKS add\-on](#removing-vpc-cni-eks-add-on) sections\. For more information about Amazon EKS add\-ons, see [Amazon EKS add\-ons](eks-add-ons.md)\.
 
-If you have not added the Amazon VPC CNI Amazon EKS add\-on, the Amazon VPC CNI add\-on is still running on your cluster\. You can manually update the `kube-proxy` add\-on using the procedure in the [Updating the Amazon VPC CNI add\-on](#updating-vpc-cni-add-on) section\.
+If you have not added the Amazon VPC CNI Amazon EKS add\-on, the Amazon VPC CNI add\-on is still running on your cluster\. You can manually update the `kube-proxy` add\-on using the procedure in the [Updating the Amazon VPC CNI add\-on manually](#updating-vpc-cni-add-on) section\.
 
 ## Adding the Amazon VPC CNI Amazon EKS add\-on<a name="adding-vpc-cni-eks-add-on"></a>
 
@@ -54,7 +54,7 @@ We recommend adding `--service-account-role-arn` `my-ARN` to the previous comman
 
 ## Updating the Amazon VPC CNI Amazon EKS add\-on<a name="updating-vpc-cni-eks-add-on"></a>
 
-This procedure is for updating the Amazon VPC CNI Amazon EKS add\-on\. If you haven't added the Amazon VPC CNI Amazon EKS add\-on, complete the procedure in [Updating the Amazon VPC CNI add\-on](#updating-vpc-cni-add-on) instead\. Amazon EKS does not automatically update the VPC CNI add\-on when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update the Amazon VPC CNI add\-on for an existing cluster, you must initiate the update and then Amazon EKS updates the add\-on for you\. 
+This procedure is for updating the Amazon VPC CNI Amazon EKS add\-on\. If you haven't added the Amazon VPC CNI Amazon EKS add\-on, complete the procedure in [Updating the Amazon VPC CNI add\-on manually](#updating-vpc-cni-add-on) instead\. Amazon EKS does not automatically update the VPC CNI add\-on when new versions are released or after you [update your cluster](update-cluster.md) to a new Kubernetes minor version\. To update the Amazon VPC CNI add\-on for an existing cluster, you must initiate the update and then Amazon EKS updates the add\-on for you\. 
 
 ------
 #### [ AWS Management Console ]
@@ -159,9 +159,9 @@ aws eks delete-addon --cluster-name my-cluster --addon-name vpc-cni
 
 ------
 
-## Updating the Amazon VPC CNI add\-on<a name="updating-vpc-cni-add-on"></a>
+## Updating the Amazon VPC CNI add\-on manually<a name="updating-vpc-cni-add-on"></a>
 
-If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the Amazon VPC CNI add\-on to, complete the following steps to update the add\-on\. If you've added the Amazon VPC CNI Amazon EKS add\-on, complete the procedure in [Updating the Amazon VPC CNI Amazon EKS add\-on](#updating-vpc-cni-eks-add-on) instead\.
+If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you have not added the Amazon VPC CNI add\-on to, complete the following steps to update the add\-on manually\. If you've added the Amazon VPC CNI Amazon EKS add\-on, complete the procedure in [Updating the Amazon VPC CNI Amazon EKS add\-on](#updating-vpc-cni-eks-add-on) instead\.
 
 **To determine your current Amazon VPC CNI add\-on version**
 + Use the following command to determine your cluster's CNI version:


### PR DESCRIPTION
A few simple changes to make clear the difference between EKS add-on and manual add-on instructions. "Add-on" is overloaded, hoping this helps clarify.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
