### PR TITLE
fix cni manifest URL for manual update.

### DIFF
--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -174,32 +174,32 @@ If you have a 1\.17 or earlier cluster, or a 1\.18 or later cluster that you hav
   amazon-k8s-cni:1.6.3
   ```
 
-  In this example output, the CNI version is 1\.6\.3, which is earlier than the latest patch for version 1\.7\.5\. Use the following procedure to update the CNI\.
+  In this example output, the CNI version is 1\.6\.3, which is earlier than the latest patch for version 1\.7\.10\. Use the following procedure to update the CNI\.
 
 **To update the Amazon VPC CNI add\-on**
-+ If your CNI version is earlier than the latest patch for minor version 1\.7\.5, and you are managing the plugin yourself, then use the appropriate command below to update your CNI version to the latest patch for minor version 1\.7\.5\. You can view the [latest patch version](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.7/aws-k8s-cni.yaml#L156) on GitHub\. If you have a cluster version 1\.18 or later with eks\.3 platform version or later, and are using the the Amazon VPC CNI Amazon EKS add\-on, then to update the add\-on, see [Updating the `kube-proxy` Amazon EKS add\-on](managing-kube-proxy.md#updating-kube-proxy-eks-add-on)\.
++ If your CNI version is earlier than the latest patch for minor version 1\.7\.10, and you are managing the plugin yourself, then use the appropriate command below to update your CNI version to the latest patch for minor version 1\.7\.10\. You can view the [latest patch version](https://github.com/aws/amazon-vpc-cni-k8s/blob/master/config/v1.7/aws-k8s-cni.yaml#L156) on GitHub\. If you have a cluster version 1\.18 or later with eks\.3 platform version or later, and are using the the Amazon VPC CNI Amazon EKS add\-on, then to update the add\-on, see [Updating the `kube-proxy` Amazon EKS add\-on](managing-kube-proxy.md#updating-kube-proxy-eks-add-on)\.
 **Important**  
 Any changes you've made to the plugin's default settings on your cluster can be overwritten with default settings when applying the new version of the manifest\. To prevent loss of your custom settings, download the manifest, change the default settings as necessary, and then apply the modified manifest to your cluster\. 
   + China \(Beijing\) \(`cn-north-1`\) or China \(Ningxia\) \(`cn-northwest-1`\)
 
     ```
-    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7.5/config/v1.7.5/aws-k8s-cni-cn.yaml
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/aws-k8s-cni-cn.yaml
     ```
   + AWS GovCloud \(US\-East\) \(`us-gov-east-1`\)
 
     ```
-    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7.5/config/v1.7.5/aws-k8s-cni-us-gov-east-1.yaml
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/aws-k8s-cni-us-gov-east-1.yaml
     ```
   + AWS GovCloud \(US\-West\) \(`us-gov-west-1`\)
 
     ```
-    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7.5/config/v1.7.5/aws-k8s-cni-us-gov-west-1.yaml
+    kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/aws-k8s-cni-us-gov-west-1.yaml
     ```
   + For all other Regions
     + Download the manifest file\.
 
       ```
-      curl -o aws-k8s-cni.yaml https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7.5/config/v1.7.5/aws-k8s-cni.yaml
+      curl -o aws-k8s-cni.yaml https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7/config/v1.7/aws-k8s-cni.yaml
       ```
     + If necessary, replace `<region-code>` in the following command with the Region that your cluster is in and then run the modified command to replace the Region code in the file \(currently `us-west-2`\)\.
 


### PR DESCRIPTION
The manifest URL appears to be incorrect when manually updating the VPC CNI version.
This PR fixes it.

e.g.)

```
curl -o /dev/null -v -s https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/release-1.7.5/config/v1.7.5/aws-k8s-cni.yaml
(snip)
< HTTP/2 404
(snip)
```



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
