### PR TITLE
fix helm to install aws-efs-csi-driver

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -169,8 +169,8 @@ This procedure requires Helm V3 or later\. To install or upgrade Helm, see [Usin
    helm upgrade -i aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver \
        --namespace kube-system \
        --set image.repository=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-efs-csi-driver \
-       --set serviceAccount.controller.create=false \
-       --set serviceAccount.controller.name=efs-csi-controller-sa
+       --set controller.serviceAccount.create=false \
+       --set controller.serviceAccount.name=efs-csi-controller-sa
    ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

serviceAccount.controller should be controller.serviceAccount

https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/cc56c4c500bbf7aaea129d1f03d6ee03903e6623/charts/aws-efs-csi-driver/values.yaml#L67

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
