### PR TITLE
Fix user data example in launch-templates.md

### DIFF
--- a/doc_source/launch-templates.md
+++ b/doc_source/launch-templates.md
@@ -74,7 +74,7 @@ You can combine multiple user data blocks together into a single MIME multi\-par
   #!/bin/bash
   echo "Running custom user data script"
   
-  --==MYBOUNDARY==--\
+  --==MYBOUNDARY==
   ```
 
 ## Using a custom AMI<a name="launch-template-custom-ami"></a>


### PR DESCRIPTION
*Issue #, if available:*

I get a fatal error that halts `cloud-init` before the bootstrap.sh is run: `/var/lib/cloud/instance/scripts/part-001: line 16: --==MYBOUNDARY==--: command not found`

1. last line of the example has `--==MYBOUNDARY==--\` which doesn't match the declared boundary, because of the trailing `\`.
2. `--==BOUNDARY==--` is not recognized by `cloud-init` (see error above), even though it should be valid from the RFC [RFC 1341](https://www.w3.org/Protocols/rfc1341/7_2_Multipart.html). Also I am pretty sure this isn't the last boundary in some cases, as EKS is merging in their own section after this (when NOT using a custom AMI). With a Custom AMI the trailing '--' probably works, it isn't needed though, so removing makes the example work both ways.

*Description of changes:*

Remove the `--\` from the end of the example multipart User Data.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
