### PR TITLE
Update cni-metrics-helper.md

### DIFF
--- a/doc_source/cni-metrics-helper.md
+++ b/doc_source/cni-metrics-helper.md
@@ -20,7 +20,7 @@ The following metrics are collected for your cluster and exported to CloudWatch:
 
 ## Deploying the CNI metrics helper<a name="install-metrics-helper"></a>
 
-The CNI metrics helper requires `cloudwatch:PutMetricData` permissions to send metric data to CloudWatch\. This section helps you to create an IAM policy with those permissions, apply it to your node instance role, and then deploy the CNI metrics helper\.
+The CNI metrics helper requires `cloudwatch:PutMetricData` permissions to send metric data to CloudWatch\. It also uses the EC2 instance tag data to populate the CloudWatch metric namespace.  This section helps you to create an IAM policy with those permissions, apply it to your node instance role, and then deploy the CNI metrics helper\.
 
 **To create an IAM policy for the CNI metrics helper**
 
@@ -32,7 +32,10 @@ The CNI metrics helper requires `cloudwatch:PutMetricData` permissions to send m
      "Statement": [
        {
          "Effect": "Allow",
-         "Action": "cloudwatch:PutMetricData",
+         "Action": [
+           "cloudwatch:PutMetricData",
+           "ec2:DescribeTags",
+         ],
          "Resource": "*"
        }
      ]


### PR DESCRIPTION
The cni metrics helper uses EC2 DescribeTags to collect the cluster information, otherwise all metrics will be emit to the same namespace k8s-cluster.

*Issue #, if available:*

*Description of changes:*

Update the CNI Helper information to have a more correct IAM Policy.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
