### PR TITLE
Fix missing information

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -185,6 +185,10 @@ Example output
 
   1. First, retrieve your current `kube-proxy` image:
 
+     ```
+     kubectl get ds kube-proxy --namespace kube-system -o=jsonpath='{$.spec.template.spec.containers[:1].image}'
+     ```
+
   1. Update `kube-proxy` to the version that Amazon EKS deploys with new clusters from the previous [table](#kube-proxy-versions) by replacing *`602401143452`*, *`us-west-2`*, and *`com`* with the values from your output and replace *`1.20.4`* with your cluster's recommended `kube-proxy` version\. If you're deploying a version that is earlier than `1.20.4`, then replace `eksbuild.2` with `eksbuild.1`\.
 
      ```


### PR DESCRIPTION
1. `kube-proxy` image retrieving instruction is lost
2. The same part and the step 2, instructions to update kube-proxy, are both lost on AWS official document - [] Managing the <code class="code">kube-proxy</code> add-on  - Updating the <code class="code">kube-proxy</code> add-on manually  - https://docs.aws.amazon.com/eks/latest/userguide/managing-kube-proxy.html#updating-kube-proxy-add-on

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
