### PR TITLE
Update security-groups-for-pods.md

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -97,7 +97,7 @@ The trunk network interface is included in the maximum number of network interfa
       spec:
         podSelector: 
           matchLabels:
-            <role>: <my-role>
+            role: <my-role>
         securityGroups:
           groupIds:
             - <sg-abc123>


### PR DESCRIPTION
*Description of changes:*

Putting brackets around \<role\> makes it look like a key that needs to be substituted, while in reality the policy yaml needs to contain the literal key named "role", without any brackets.  Since I used the sample policy as a reference, it took me a while to figure out the typo in the key, as the failure mode is very subtle.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
