### PR TITLE
Newline error with <>

### DIFF
--- a/doc_source/enable-iam-roles-for-service-accounts.md
+++ b/doc_source/enable-iam-roles-for-service-accounts.md
@@ -24,7 +24,7 @@ An existing cluster\. If you don't have one, you can create one using one of the
    List the IAM OIDC providers in your account\. Replace *`<EXAMPLED539D4633E53DE1B716D3041E>`* \(including *`<>`*\) with the value returned from the previous command\.
 
    ```
-   aws iam list-open-id-connect-providers | grep <EXAMPLED539D4633E53DE1B716D3041E>
+   aws iam list-open-id-connect-providers | grep EXAMPLED539D4633E53DE1B716D3041E
    ```
 
    Example output


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*
Adding <> in the grep throws a newline error, it works without having to add *<>*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
