### PR TITLE
mention of `--balancing-ignore-label` in documentation

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -226,7 +226,13 @@ Review the following considerations to optimize your Cluster Autoscaler deployme
 The Cluster Autoscaler can be configured to include any additional features of your nodes\. These features can include Amazon EBS volumes attached to nodes, Amazon EC2 instance types of nodes, or GPU accelerators\. 
 
 **Scope node groups across more than one Availability Zone**  
-We recommend that you configure multiple node groups, scope each group to a single Availability Zone, and enable the `--balance-similar-node-groups` feature\. If you only create one node group, scope that node group to span over more than one Availability Zone\.
+We recommend that you configure multiple node groups, scope each group to a single Availability Zone, and enable the `--balance-similar-node-groups` feature\. When using this feature, ensure that any node label that may be different across nodes of multiple node groups is each passed to a `--balancing-ignore-label` flag.
+```
+        - --balancing-ignore-label=eks.amazonaws.com/sourceLaunchTemplateId
+        - --balancing-ignore-label=eks.amazonaws.com/sourceLaunchTemplateVersion
+```
+
+If you only create one node group, scope that node group to span over more than one Availability Zone\.
 
 **Optimize your node groups**  
 The Cluster Autoscaler makes assumptions about how you're using node groups\. This includes which instance types that you use within a group\. To align with these assumptions, configure your node group based on these considerations and recommendations: 

--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -226,7 +226,7 @@ Review the following considerations to optimize your Cluster Autoscaler deployme
 The Cluster Autoscaler can be configured to include any additional features of your nodes\. These features can include Amazon EBS volumes attached to nodes, Amazon EC2 instance types of nodes, or GPU accelerators\. 
 
 **Scope node groups across more than one Availability Zone**  
-We recommend that you configure multiple node groups, scope each group to a single Availability Zone, and enable the `--balance-similar-node-groups` feature\. When using this feature, ensure that any node label that may be different across nodes of multiple node groups is each passed to a `--balancing-ignore-label` flag.
+We recommend that you configure multiple node groups, scope each group to a single Availability Zone, and enable the `--balance-similar-node-groups` feature\. When using this feature, every node label that may be different across nodes of multiple node groups must each be passed to one `--balancing-ignore-label` flag.
 
 If you only create one node group, scope that node group to span over more than one Availability Zone\.
 

--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -227,10 +227,6 @@ The Cluster Autoscaler can be configured to include any additional features of y
 
 **Scope node groups across more than one Availability Zone**  
 We recommend that you configure multiple node groups, scope each group to a single Availability Zone, and enable the `--balance-similar-node-groups` feature\. When using this feature, ensure that any node label that may be different across nodes of multiple node groups is each passed to a `--balancing-ignore-label` flag.
-```
-        - --balancing-ignore-label=eks.amazonaws.com/sourceLaunchTemplateId
-        - --balancing-ignore-label=eks.amazonaws.com/sourceLaunchTemplateVersion
-```
 
 If you only create one node group, scope that node group to span over more than one Availability Zone\.
 


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awsdocs/amazon-eks-user-guide/issues/411
*Description of changes:*
This relates to issue [kubernetes/autoscaler#3515](https://github.com/kubernetes/autoscaler/issues/3515)

When using --balance-similar-node-groups=true to balance scaling across multiple node groups, each in a different AZ, scaling across node group ASGs is not uniform unless all node labels match.

I created 3 node groups using eksctl (each in a different AZ) and found that a node label eks.amazonaws.com/sourceLaunchTemplateId (and possibly eks.amazonaws.com/sourceLaunchTemplateVersion) is different across nodes of different node groups. Scaling was not uniform unless I passed --balancing-ignore-label=eks.amazonaws.com/sourceLaunchTemplateId. This labels is not covered in the list of aws ignored labels or BasicIgnoredLabels.

Think it will be useful to include a note in documentation so that user can compare the node labels and pass --balancing-ignore-label for each label that needs ignoring.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
