### PR TITLE
Update fargate-logging.md

### DIFF
--- a/doc_source/fargate-logging.md
+++ b/doc_source/fargate-logging.md
@@ -86,12 +86,13 @@ In the following steps, replace the `<example values>` with your own values\.
              [OUTPUT]
                Name  es
                Match *
-               Host  192.168.2.3
-               Port  9200
+               Host  vpc-test-domain-ke7thhzoo7jawsrhmm6mb7ite7y.us-west-2.es.amazonaws.com
+               Port  443
                Index my_index
                Type  my_type
                AWS_Auth On
-               AWS_Region <us-east-1>
+               AWS_Region <us-west-2>
+               tls     On
          ```
 
       1. Apply the manifest to your cluster\.


### PR DESCRIPTION
The port number needs to be changed to 443. I tested this config mentioned in document with AWS ElasticSearch and it didn't work on 9200. Found the same thing in fluentbit documentation. Fluentbit Documentation link. https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch##aws-es

*Issue #, if available:*

*Description of changes:*
The OUTPUT Config described for target AWS ElasticSearch is not working. For AWS Elasticsearch the port needs to be changed to 443. Same has been mentioned in fluentbit document 
https://docs.fluentbit.io/manual/pipeline/outputs/elasticsearch##aws-es


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
