### PR TITLE
Use the raw endpoint for max-pods-calculator.sh

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -102,7 +102,7 @@ Ensure that an annotation with the key `k8s.amazonaws.com/eniConfig` for the `EN
    1. Download a script that you can use to calculate the maximum number of pods for each instance type\.
 
       ```
-      curl -o max-pods-calculator.sh https://github.com/awslabs/amazon-eks-ami/blob/master/files/max-pods-calculator.sh
+      curl -o max-pods-calculator.sh https://raw.githubusercontent.com/awslabs/amazon-eks-ami/master/files/max-pods-calculator.sh
       ```
 
    1. Mark the script as executable on your computer\.


### PR DESCRIPTION
*Issue #, if available:*
The URL for the `max-pods-calculator.sh` references the GitHub repo page so the `curl` command as given downloads the HTML for the page rather than the script.

*Description of changes:*
Updated the URL for `max-pods-calculator.sh` to use the raw GitHub endpoint.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
