### PR TITLE
Fix NCCL test file path for EFA on EKS

### DIFF
--- a/doc_source/node-efa.md
+++ b/doc_source/node-efa.md
@@ -271,7 +271,7 @@ Complete the following steps to run a two node NCCL Performance Test\. In the ex
 1. Create the NCCL\-tests job\.
 
    ```
-   kubectl apply -f https://raw.githubusercontent.com/aws-samples/aws-efa-eks/main/examples/nccl-efa-tests.yaml
+   kubectl apply -f https://raw.githubusercontent.com/aws-samples/aws-efa-eks/main/examples/simple/nccl-efa-tests.yaml
    ```
 
    Output


### PR DESCRIPTION
*Issue #, if available:* #429

*Description of changes:*
Fixing url of NCCL test job

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
