### PR TITLE
Update cluster-autoscaler.md

### DIFF
--- a/doc_source/cluster-autoscaler.md
+++ b/doc_source/cluster-autoscaler.md
@@ -73,7 +73,7 @@ Create an IAM policy that grants the permissions that the Cluster Autoscaler req
         --cluster=<my-cluster> \
         --namespace=kube-system \
         --name=cluster-autoscaler \
-        --attach-policy-arn=arn:aws::<AWS_ACCOUNT_ID>:policy/<AmazonEKSClusterAutoscalerPolicy> \
+        --attach-policy-arn=arn:aws:iam::<AWS_ACCOUNT_ID>:policy/<AmazonEKSClusterAutoscalerPolicy> \
         --override-existing-serviceaccounts \
         --approve
       ```


### PR DESCRIPTION
Arn Policy listed has a typo and it makes cloudformation to fail with invalid policy error.  Corrected the typo.

From  "arn:aws::<AWS_ACCOUNT_ID>:policy/<AmazonEKSClusterAutoscalerPolicy>" to "arn:aws:iam::<AWS_ACCOUNT_ID>:policy/<AmazonEKSClusterAutoscalerPolicy>" in Line 76

*Issue #, if available:* IAM Policy Typo

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
