### PR TITLE
Fix trusted entity for the role

### DIFF
--- a/doc_source/using-service-linked-roles-eks.md
+++ b/doc_source/using-service-linked-roles-eks.md
@@ -16,7 +16,7 @@ Amazon EKS uses the service\-linked role named `AWSServiceRoleForAmazonEKS` – 
 The `AWSServiceRoleForAmazonEKS` service\-linked role is distinct from the role required for cluster creation\. For more information, see [Amazon EKS cluster IAM role](service_IAM_role.md)\.
 
 The `AWSServiceRoleForAmazonEKS` service\-linked role trusts the following services to assume the role:
-+ `eks-fargate.amazonaws.com`
++ `eks.amazonaws.com`
 
 The role permissions policy allows Amazon EKS to complete the following actions on the specified resources:
 + [https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/aws-service-role/AmazonEKSServiceRolePolicy$jsonEditor](https://console.aws.amazon.com/iam/home#/policies/arn:aws:iam::aws:policy/aws-service-role/AmazonEKSServiceRolePolicy$jsonEditor)


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
The `AWSServiceRoleForAmazonEKS` service\-linked role trusted entity is `eks.amazonaws.com`, not `eks-fargate.amazonaws.com`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
