### PR TITLE
Improve 'kubectl' cmd call

### DIFF
--- a/doc_source/cni-iam-role.md
+++ b/doc_source/cni-iam-role.md
@@ -27,7 +27,7 @@ You can use `eksctl` or the AWS Management Console to create your CNI plugin IAM
 1. Describe one of the pods and verify that the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables exist\.
 
    ```
-   kubectl exec -n kube-system aws-node-<9rgzw> env | grep AWS
+   kubectl exec -n kube-system aws-node-<9rgzw> -c aws-node -- env | grep AWS
    ```
 
    Output:

--- a/doc_source/cni-iam-role.md
+++ b/doc_source/cni-iam-role.md
@@ -109,7 +109,7 @@ You must have an existing IAM OIDC provider for your cluster\. To determine whet
 1. Describe one of the pods and verify that the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables exist\.
 
    ```
-   kubectl exec -n kube-system aws-node-<9rgzw> env | grep AWS
+   kubectl exec -n kube-system aws-node-<9rgzw> -c aws-node -- env | grep AWS
    ```
 
    Output:


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
To remove `kubectl` complaints on deprecated invocation mode and defaulted container, like:
```
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
Defaulted container "aws-node" out of: aws-node, aws-vpc-cni-init (init)
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
