### PR TITLE
mandatory security group tag

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -10,6 +10,9 @@ Before you can load balance application traffic to an application, you must meet
 + Have an existing cluster\. If you don't have an existing cluster, see [Getting started with Amazon EKS](getting-started.md)\. If you need to update the version of an existing cluster, see [Updating a cluster](update-cluster.md)\.
 + The AWS Load Balancer Controller provisioned on your cluster\. For more information, see [AWS Load Balancer Controller](aws-load-balancer-controller.md)\.
 + At least two subnets in different Availability Zones\. The AWS load balancer controller chooses one subnet from each Availability Zone\. When multiple tagged subnets are found in an Availability Zone, the controller chooses the subnet whose subnet ID comes first lexicographically\.
++ If you're using multiple security groups attached to worker node, exactly any one security group must be tagged as follows\. Replace *`cluster-name`* with your cluster name\.  
+  + **Key** – `kubernetes.io/cluster/cluster-name`
+  + **Value** – `shared` or `owned`
 + If you're using the AWS Load Balancer controller version `v2.1.1` or earlier, subnets must be tagged in the format that follows\. If you're using version 2\.1\.2 or later, tagging is optional\. However, we recommend that you tag a subnet if any of the following is the case\. You have multiple clusters that are running in the same VPC, or have multiple AWS services that share subnets in a VPC\. Or, you want more control over where load balancers are provisioned for each cluster\. Replace `cluster-name` with your cluster name\.
   + **Key** – `kubernetes.io/cluster/cluster-name`
   + **Value** – `shared` or `owned`

--- a/doc_source/network-load-balancing.md
+++ b/doc_source/network-load-balancing.md
@@ -13,6 +13,9 @@ With the `2.2.0` release of the [AWS Load Balancer Controller](aws-load-balancer
 
 Before you can load balance network traffic to an application, you must meet the following requirements\.
 + At least one subnet\. If multiple tagged subnets are found in an Availability Zone, the controller chooses the first subnet whose subnet ID comes first lexicographically\.
++ If you're using multiple security groups attached to worker node, exactly any one security group must be tagged as follows\. Replace *`cluster-name`* with your cluster name\.  
+  + **Key** – `kubernetes.io/cluster/cluster-name`
+  + **Value** – `shared` or `owned`
 + If you're using the AWS Load Balancer controller version `v2.1.1` or earlier, subnets must be tagged as follows\. If using version 2\.1\.2 or later, this tag is optional\. You might want to tag a subnet if you have multiple clusters running in the same VPC, or multiple AWS services sharing subnets in a VPC, and want more control over where load balancers are provisioned for each cluster\. If you explicitly specify subnet IDs as an annotation on a Service object, then Kubernetes and the AWS Load Balancer Controller use those subnets directly to create the load balancer\. Subnet tagging isn't required if you choose to use this method for provisioning load balancers and you can skip the following private and public subnet tagging requirements\. Replace *`cluster-name`* with your cluster name\.
   + **Key** – `kubernetes.io/cluster/cluster-name`
   + **Value** – `shared` or `owned`


### PR DESCRIPTION

*Description of changes:*
AWS load balancer controller requires exactly one sec group to be tagged with kubernetes.io/cluster/<cluster-name> when attached multiple security groups to the worker node.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
