### PR TITLE
Breaking change - Regression on Helm Chart values based on user preferred method of installation

### DIFF
--- a/doc_source/ebs-csi.md
+++ b/doc_source/ebs-csi.md
@@ -141,6 +141,7 @@ For detailed descriptions of all the available parameters and complete examples 
 
    1. Install a release of the driver using the Helm chart\. If your cluster isn't in the `us-west-2` Region, then change `602401143452.dkr.ecr.us-west-2.amazonaws.com` to your Region's [container image address](add-ons-images.md)\.
 
+      If you have used eksctl in Step 2
       ```
       helm upgrade -install aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
       --namespace kube-system \
@@ -150,7 +151,18 @@ For detailed descriptions of all the available parameters and complete examples 
       --set controller.serviceAccount.create=false \
       --set controller.serviceAccount.name=ebs-csi-controller-sa
       ```
-
+      If you have used AWS CLI in Step 2 then set the ```controller.serviceAccount.create=true``` and ```controller.serviceAccount.annotations``` with the correct Role ARN that you have created
+      ```
+      helm upgrade -install aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
+      --namespace kube-system \
+      --set image.repository=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver \
+      --set enableVolumeResizing=true \
+      --set enableVolumeSnapshot=true \
+      --set controller.serviceAccount.create=true \
+      --set controller.serviceAccount.name=ebs-csi-controller-sa
+      --set controller.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::111122223333:role/AmazonEKS_EBS_CSI_DriverRole
+      ```
+      
 ------
 #### [ Manifest ]
 


### PR DESCRIPTION
This [commit](https://github.com/awsdocs/amazon-eks-user-guide/commit/db7b94af6558dcff6f60950eeb75d0001b786205#diff-e7809e03680f9563e42df4cd5c548f36f2e4265c7aa408c48b70916e5ab9d8b9) helped to solve the way values are referenced in the [values.yaml](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/master/charts/aws-ebs-csi-driver/values.yaml) file of Helm Chart. However the commit also set ```controller.serviceAccount.create=false``` hence breaking sequence of logical steps that end user follows.

Before committing this pull request:

Steps that end user may follow:
1. Step 1A and 1B to create policy
2. Step 2, I have chosen AWS CLI method [hence no SA getting created]
3. Step 3, I have chosen Helm chart method, which currently has ```controller.serviceAccount.create=false``` hence service account will not get created however the csi controller is referencing this service account. Hence in overall installation perspective ```ebs-csi-node``` DaemonSet pods will get created but ```ebs-csi-controller``` will not get created with error as Service Account not found.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
