### PR TITLE
Remove obsolete enableVolumeResizing and enableVolumeSnapshot ebs csi helm values

### DIFF
--- a/doc_source/ebs-csi.md
+++ b/doc_source/ebs-csi.md
@@ -147,8 +147,6 @@ For detailed descriptions of all the available parameters and complete examples 
       helm upgrade -install aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
           --namespace kube-system \
           --set image.repository=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver \
-          --set enableVolumeResizing=true \
-          --set enableVolumeSnapshot=true \
           --set controller.serviceAccount.create=false \
           --set controller.serviceAccount.name=ebs-csi-controller-sa
       ```
@@ -159,8 +157,6 @@ For detailed descriptions of all the available parameters and complete examples 
       helm upgrade -install aws-ebs-csi-driver aws-ebs-csi-driver/aws-ebs-csi-driver \
           --namespace kube-system \
           --set image.repository=602401143452.dkr.ecr.us-west-2.amazonaws.com/eks/aws-ebs-csi-driver \
-          --set enableVolumeResizing=true \
-          --set enableVolumeSnapshot=true \
           --set controller.serviceAccount.create=true \
           --set controller.serviceAccount.name=ebs-csi-controller-sa \
           --set controller.serviceAccount.annotations."eks\.amazonaws\.com/role-arn"="arn:aws:iam::111122223333:role/AmazonEKS_EBS_CSI_DriverRole"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* These values were removed from the latest helm chart. The volume resizing and volume snapshot features are enabled by default in both install methods (helm and kustomize/yaml) so setting them isn't needed anymore as it doesn't do anything. Ref: https://github.com/kubernetes-sigs/aws-ebs-csi-driver/blob/release-1.3/charts/aws-ebs-csi-driver/values.yaml

subset of https://github.com/awsdocs/amazon-eks-user-guide/pull/428


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
