### PR TITLE
fix requirement for ELB VPC Endpoint.

### DIFF
--- a/doc_source/private-clusters.md
+++ b/doc_source/private-clusters.md
@@ -79,7 +79,7 @@ The following [VPC endpoints](https://docs.aws.amazon.com/vpc/latest/userguide/v
 + `com.amazonaws.<region>.s3` – For pulling container images
 + `com.amazonaws.<region>.logs` – For CloudWatch Logs
 + `com.amazonaws.<region>.sts` – If using Cluster Autoscaler or IAM roles for service accounts
-+ `com.amazonaws.<region>.elasticloadbalancing` – If using Application Load Balancers
++ `com.amazonaws.<region>.elasticloadbalancing` – If using AWS Load Balancer Controller
 + `com.amazonaws.<region>.autoscaling` – If using Cluster Autoscaler
 + `com.amazonaws.<region>.appmesh-envoy-management` – If using App Mesh
 


### PR DESCRIPTION
*Issue #, if available:*

The requirement for ELB VPC endpoints when creating a Private cluster are not accurate.
Some users are using ALB without the AWS Load Balancer Controller.
And there is no description of NLB.

*Description of changes:*

I changed "Application Load Balancers" to "AWS Load Balancer Controller".

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
