### PR TITLE
Added note to use separate IAM roles for the windows and linux nodes

### DIFF
--- a/doc_source/launch-windows-workers.md
+++ b/doc_source/launch-windows-workers.md
@@ -139,6 +139,7 @@ If you select AWS Outposts, AWS Wavelength, or AWS Local Zones subnets, then the
    1. Open the file with your favorite text editor\. Replace the *`<ARN of instance role (not instance profile) of **Linux** node>`* and *`<ARN of instance role (not instance profile) of **Windows** node>`* snippets with the **NodeInstanceRole** values that you recorded for your Linux and Windows nodes, and save the file\.
 **Important**  
 Do not modify any other lines in this file\.
+Do not use the same IAM role for both Windows and Linux nodes.
 
       ```
       apiVersion: v1


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We have seen users don't use separate roles for their Windows and Linux nodes. 
This causes issues with DNS name resolution similar to [this](https://repost.aws/questions/QUsFW_rlmuRvKpVEs0KMuYoA).
Added a note to not use the same role for both Windows and Linux nodes in the important section before the aws-auth config map. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
