### PR TITLE
Update efs-csi.md

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -181,11 +181,13 @@ This procedure requires Helm V3 or later\. To install or upgrade Helm, see [Usin
 ------
 #### [ Manifest ]
 
+A. **OPTION A: Use images stored in Private ECR Registry**
+
 1. Download the manifest\.
 
    ```
    kubectl kustomize \
-       "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr?ref=release-1.3" > driver.yaml
+       "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr?ref=release-1.3" > private-ecr-driver.yaml
    ```
 
 1. Edit the file and remove the following lines that create a Kubernetes service account\. This isn't necessary because the service account was created in a previous step\. 
@@ -210,7 +212,35 @@ This procedure requires Helm V3 or later\. To install or upgrade Helm, see [Usin
 1. Apply the manifest\.
 
    ```
-   kubectl apply -f driver.yaml
+   kubectl apply -f private-ecr-driver.yaml
+   ```
+
+B. **OPTION B: Use images stored in Public ECR Registry**
+
+1. Download the manifest\.
+
+   ```
+   kubectl kustomize \
+       "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.3" > public-ecr-driver.yaml
+   ```
+
+1. Edit the file and remove the following lines that create a Kubernetes service account\. This isn't necessary because the service account was created in a previous step\. 
+
+   ```
+   apiVersion: v1
+   kind: ServiceAccount
+   metadata:
+     labels:
+       app.kubernetes.io/name: aws-efs-csi-driver
+     name: efs-csi-controller-sa
+     namespace: kube-system
+   ---
+   ```
+
+1. Apply the manifest\.
+
+   ```
+   kubectl apply -f public-ecr-driver.yaml
    ```
 
 ------


### PR DESCRIPTION
## [Issue Description]
In some cases where Organization that has strict security policies which DO NOT allow any IAM role/user to authenticate/pull images from AWS owned Private registry account, than the documented steps in "Install the Amazon EFS driver" >> "Manifest" does not work.  

## [Description of changes]
Added two OPTION A. (Use images stored in Private ECR Registry) and B. (Use images stored in Public ECR Registry) under "Install the Amazon EFS driver" >> "Manifest" so that user have a flexibility to use the appropriate Registry to pull EFS Driver images.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
