### PR TITLE
Fix syntax of controller service account object creation

### DIFF
--- a/doc_source/aws-load-balancer-controller.md
+++ b/doc_source/aws-load-balancer-controller.md
@@ -118,7 +118,7 @@ If you view the policy in the AWS Management Console, you may see warnings for E
         name: aws-load-balancer-controller
         namespace: kube-system
         annotations:
-            eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/AmazonEKSLoadBalancerControllerRole
+          eks.amazonaws.com/role-arn: arn:aws:iam::111122223333:role/AmazonEKSLoadBalancerControllerRole
       ```
 
    1. Create the service account on your cluster\.


### PR DESCRIPTION
There were 4 spaces in the `annotations` section so the actual IAM role annotation was ignored by the API server and stripped out, causing the controller to assume the instance role and not be able to function.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
