### PR TITLE
Update eks cluster oidc provider url

### DIFF
--- a/doc_source/create-service-account-iam-policy-and-role.md
+++ b/doc_source/create-service-account-iam-policy-and-role.md
@@ -126,7 +126,7 @@ An AWS CloudFormation template is deployed that creates an IAM role and attaches
 1. Find the line that looks similar to the following:
 
    ```
-   "oidc.eks.region-code/id/EXAMPLED539D4633E53DE1B716D3041E:aud": "sts.amazonaws.com"
+   "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B716D3041E:aud": "sts.amazonaws.com"
    ```
 
    Change the line to look like the following line\. Replace *`EXAMPLED539D4633E53DE1B716D3041E`* with your cluster's OIDC provider ID and replace *region\-code* with the AWS Region code that your cluster is in\. Replace *aud* with **sub** and replace *KUBERNETES\_SERVICE\_ACCOUNT\_NAMESPACE* and *KUBERNETES\_SERVICE\_ACCOUNT\_NAME* with the name of your Kubernetes service account and the Kubernetes namespace that the account exists in\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updates eks cluster OIDC provider URL in IAM Role's trust relationship part.
Current example's OIDC provider url lacks `amazonaws.com`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
