### PR TITLE
Update documentation aws-load-balancer-controller.md

### DIFF
--- a/doc_source/aws-load-balancer-controller.md
+++ b/doc_source/aws-load-balancer-controller.md
@@ -255,7 +255,7 @@ The deployed chart doesn't receive security updates automatically\. You need to 
 
            ```
            quay.io/jetstack/cert-manager-cainjector:v1.5.4
-           quay.io/jetstack/cert-manager-cainjector:v1.5.4
+           quay.io/jetstack/cert-manager-controller:v1.5.4
            quay.io/jetstack/cert-manager-webhook:v1.5.4
            ```
 


### PR DESCRIPTION
duplicate entry exists for quay.io/jetstack/cert-manager-cainjector, while quay.io/jetstack/cert-manager-controller was missing

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
