### PR TITLE
updated doc

### DIFF
--- a/doc_source/autoscaling.md
+++ b/doc_source/autoscaling.md
@@ -175,9 +175,7 @@ Complete the following steps to deploy the Cluster Autoscaler\. We recommend tha
    kubectl -n kube-system edit deployment.apps/cluster-autoscaler
    ```
 
-   Edit the `cluster-autoscaler` container command to replace `<YOUR CLUSTER NAME>` \(including *`<>`*\) with the name of your cluster, and add the following options\.
-   + `--balance-similar-node-groups`
-   + `--skip-nodes-with-system-pods=false`
+   Edit the `cluster-autoscaler` container command to replace `<YOUR CLUSTER NAME>` \(including *`<>`*\) with the name of your cluster\.
 
    ```
        spec:


### PR DESCRIPTION
*Issue #, if available:*

Adding following command under cluster-autoscaler deployment does not work. 

--balance-similar-node-groups
--skip-nodes-with-system-pods=false

*Description of changes:*

Removing these lines works perfectly fine with the cluster autoscaler. I have replicated this issue multiple times, come across the same thing. Made changes to deployment without above lines, it works fine and scale the nodes according to need. Please review and remove these. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
