### PR TITLE
Update the flag managed usage in shell script

### DIFF
--- a/doc_source/launch-workers.md
+++ b/doc_source/launch-workers.md
@@ -38,7 +38,7 @@ You must create the node group with a config file that specifies the subnets and
      --nodes-min 1 \
      --nodes-max 4 \
      --ssh-access \
-     --managed false \
+     --managed=false \
      --ssh-public-key my-key
    ```
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Using the current version of the shell script throws and error 
`Error: couldn't create node group filter from command line options: --name=al-nodes and argument managed=false cannot be used at the same time`

It will be confusing/frustrating for the users trying to run the command for the first time and receive such error

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
