### PR TITLE
fix: missing ec2:DescribeInstanceTypes permission for cluster autoscaler

### DIFF
--- a/doc_source/autoscaling.md
+++ b/doc_source/autoscaling.md
@@ -48,6 +48,7 @@ Create an IAM policy that grants the permissions that the Cluster Autoscaler req
                       "autoscaling:DescribeTags",
                       "autoscaling:SetDesiredCapacity",
                       "autoscaling:TerminateInstanceInAutoScalingGroup",
+                      "ec2:DescribeInstanceTypes",
                       "ec2:DescribeLaunchTemplateVersions"
                   ],
                   "Resource": "*",


### PR DESCRIPTION
*Issue:*

Missing `ec2:DescribeInstanceTypes` permission in https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html.

Without it, the cluster autoscaler will crash with this kind of error: 

```
E0322 10:48:59.960115       1 aws_manager.go:265] Failed to regenerate ASG cache: cannot autodiscover ASGs: WebIdentityErr: failed to retrieve credentials
caused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity
        status code: 403, request id: 9ad49cf2-xxxx-xxxx-xxxx-487b5b399ec3
F0322 10:48:59.960135       1 aws_cloud_provider.go:382] Failed to create AWS Manager: cannot autodiscover ASGs: WebIdentityErr: failed to retrieve credentials
caused by: AccessDenied: Not authorized to perform sts:AssumeRoleWithWebIdentity
```

Tested on EKS 1.20 using the official helm chart.

Solution found on the [Kubernetes Autoscaler repository](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler/cloudprovider/aws#full-cluster-autoscaler-features-policy-recommended).

*Description of changes:*

- Added `ec2:DescribeInstanceTypes` in `doc_source/autoscaling.md`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

Signed-off-by: David <davidcalvertfr@gmail.com>

