### PR TITLE
updated helm chart command

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -170,12 +170,11 @@ This procedure requires Helm V3 or later\. To install or upgrade Helm, see [Usin
    helm repo update
    ```
 
-1. Install a release of the driver using the Helm chart\. Replace the repository address with the cluster's [container image address](add-ons-images.md)\.
+1. Install a release of the driver using the Helm chart\.
 
    ```
-   helm upgrade -i aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver \
+   helm upgrade -i aws-efs-csi-driver aws-efs-csi-driver/aws-efs-csi-driver --version 2.2.4 \
        --namespace kube-system \
-       --set image.repository=123456789012.dkr.ecr.region-code.amazonaws.com/eks/aws-efs-csi-driver \
        --set controller.serviceAccount.create=false \
        --set controller.serviceAccount.name=efs-csi-controller-sa
    ```


### PR DESCRIPTION
*Issue #, if available:*

helm chart installation command does not work. It gives following error because of set repository. 

Warning  Failed     36s (x3 over 93s)  kubelet            Error: ErrImagePull
Warning  Failed     36s (x3 over 93s)  kubelet            Failed to pull image "602401143452.dkr.ecr.ap-southeast-2.amazonaws.com:v1.3.6": rpc error: code = Unknown desc = Error response from daemon: pull access denied for 602401143452.dkr.ecr.ap-southeast-2.amazonaws.com, repository does not exist or may require 'docker login': denied: requested access to the resource is denied

*Description of changes:*

I have replicated this issue and provided command install the helm chart and its running. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
