### PR TITLE
Fix url for aws-k8s-cni.yaml

### DIFF
--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -426,7 +426,7 @@ The latest and recommended versions work with all Amazon EKS supported Kubernete
       + If your cluster is in the US West \(Oregon\) \(`us-west-2`\) AWS Region then run the following command\.
 
         ```
-        kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.10.1/config/master/master/aws-k8s-cni.yaml
+        kubectl apply -f https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.10.1/config/master/aws-k8s-cni.yaml
         ```
       + If your cluster is in any other AWS Region, then complete the following steps\.
 


### PR DESCRIPTION
The doc currently states to use the following url to update the cni for the us-west-2 region: https://raw.githubusercontent.com/aws/amazon-vpc-cni-k8s/v1.10.1/config/master/master/aws-k8s-cni.yaml.  Which has the branch listed twice so it returns a 404.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
