### PR TITLE
Fix FluentBit Config File Link

### DIFF
--- a/doc_source/fargate-logging.md
+++ b/doc_source/fargate-logging.md
@@ -37,7 +37,7 @@ In the following steps, replace every `example-value` with your own values\.
       kubectl apply -f aws-observability-namespace.yaml
       ```
 
-1. Create a `ConfigMap` with a `Fluent Conf` data value to ship container logs to a destination\. Fluent Conf is Fluent Bit, which is a fast and lightweight log processor configuration language that's used to route container logs to a log destination of your choice\. For more information, see [Configuration File](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file) in the Fluent Bit documentation\. 
+1. Create a `ConfigMap` with a `Fluent Conf` data value to ship container logs to a destination\. Fluent Conf is Fluent Bit, which is a fast and lightweight log processor configuration language that's used to route container logs to a log destination of your choice\. For more information, see [Configuration File](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file) in the Fluent Bit documentation\. 
 **Important**  
 The main sections included in a typical `Fluent Conf` are `Service`, `Input`, `Filter`, and `Output`\. The Fargate log router however, only accepts:  
  The `Filter` and `Output` sections and manages the `Service` and `Input` sections itself\.


### PR DESCRIPTION
The URL for FluentBit's config file documentation changed.

*Issue #, if available:* N/A

*Description of changes:* This pull request replaces the broken URL for FluentBit's documentation with what I believe is the most suitable replacement. Readers who navigate to the [URL found on the existing documentation page](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file)  will encounter an error stating, "Sorry, but the page you were looking for could
not be found." The [URL I have replaced it with](https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/classic-mode/configuration-file) points to an existing documentation page that contains what appears to be identical information. (I compared the content of the page linked to by my proposed change against the content of the old page, as it appears on Wayback Machine: <https://web.archive.org/web/20210304131701/https://docs.fluentbit.io/manual/administration/configuring-fluent-bit/configuration-file>.)


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
