### PR TITLE
Update csi-iam-role.md

### DIFF
--- a/doc_source/csi-iam-role.md
+++ b/doc_source/csi-iam-role.md
@@ -242,8 +242,8 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
             "Action": "sts:AssumeRoleWithWebIdentity",
             "Condition": {
               "StringEquals": {
-                "oidc-provider/oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud": "sts.amazonaws.com",
-                "oidc-provider/oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
+                "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud": "sts.amazonaws.com",
+                "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:ebs-csi-controller-sa"
               }
             }
           }


### PR DESCRIPTION
In the policy condition there is a prefix "oidc-provider/" which is causing credentials issues when the EBS is being created.
I suggest to remove it from the documentation to avoid confusion.

EKS Version: 1.22
Addon: aws-ebs-csi-driver
Addon version: v1.5.2-eksbuild.1
