### PR TITLE
Fix incorrect s3 link for externalip-webhook.yaml

### DIFF
--- a/doc_source/restrict-service-external-ip.md
+++ b/doc_source/restrict-service-external-ip.md
@@ -52,7 +52,7 @@ To learn more about Kubernetes services, see [Service](https://kubernetes.io/doc
 1. Download the external IP webhook manifest\. You can also view the [source code for the webhook](https://github.com/kubernetes-sigs/externalip-webhook) on GitHub\.
 
    ```
-   curl -o externalip-webhook.yaml https://s3.us-west-2.amazonaws.com/amazon-eks//docs/externalip-webhook.yaml
+   curl -o externalip-webhook.yaml https://s3.us-west-2.amazonaws.com/amazon-eks/docs/externalip-webhook.yaml
    ```
 
 1. <a name="restrict-external-ip-addresses-cidr-block"></a>Specify CIDR blocks\. Open the downloaded file in your editor and remove the `#` at the start of the following lines\.


### PR DESCRIPTION
*Description of changes:*

- Fix incorrect s3 link for externalip-webhook.yaml

Reference Link:
- https://docs.aws.amazon.com/eks/latest/userguide/restrict-service-external-ip.html