### PR TITLE
Update adot-manage.md

### DIFF
--- a/doc_source/adot-manage.md
+++ b/doc_source/adot-manage.md
@@ -168,7 +168,7 @@ The `--resolve-conflicts OVERWRITE` option will resolve any conflicts with Amazo
   CLI
 
   ```
-  aws eks delete-addon --name adot --cluster-name your-cluster
+  aws eks delete-addon --addon-name adot --cluster-name your-cluster
   ```
 
   `eksctl`


### PR DESCRIPTION
Fix parameter for eks delete-addon

*Issue #, if available:*

*Description of changes:*

Parameter used for delete-addon is incorrect.

```
    --addon-name (string)
          The  name  of  the  add-on.  The  name  must  match one of the names
          returned
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
