### PR TITLE
Bumping version of Cert Manager Chart to v1.8.2

### DIFF
--- a/doc_source/adot-reqts.md
+++ b/doc_source/adot-reqts.md
@@ -28,7 +28,7 @@ The ADOT Operator is compatible with cert\-manager versions of less than `1.6.0`
 
    ```
    kubectl apply -f \ 
-   https://github.com/jetstack/cert-manager/releases/download/v1.5.0/cert-manager.yaml
+   https://github.com/jetstack/cert-manager/releases/download/v1.8.2/cert-manager.yaml
    ```
 
 1. Verify that cert\-manager is ready using the following command\.


### PR DESCRIPTION


*Issue #, if available:*

*Description of changes:*
Instructions indicate not to install version of cert manager version 1.6.0 or older however Step 1 in installation points to v1.5.0 of certmanager.
Bumping version of cert manager to latest. Confirmed to work with Adot Operator.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
