### PR TITLE
Kubernetes Dashboard should upgrade to v2.6.0+ to ensure its compatibility

### DIFF
--- a/doc_source/dashboard-tutorial.md
+++ b/doc_source/dashboard-tutorial.md
@@ -16,7 +16,7 @@ This tutorial assumes the following:
 + For Regions other than Beijing and Ningxia China, apply the Kubernetes dashboard\.
 
   ```
-  kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.0.5/aio/deploy/recommended.yaml
+  kubectl apply -f https://raw.githubusercontent.com/kubernetes/dashboard/v2.6.0/aio/deploy/recommended.yaml
   ```
 + For the Beijing and Ningxia China Region, download, modify, and apply the Calico manifests to your cluster\.
 


### PR DESCRIPTION
**_Description of changes:_**

Amazon EKS supportted version have major changes over years
- https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-release-calendar

but the version for Kubernetes Dashboard have not been update for years, last update was made on **_Dec 10, 2020_**.

```
commit fc59dad48cdc2258aa2070709218fde4a38d62bd
Date:   Thu, 10 Dec 2020 04:42:44 +0800
```

should consider to upgrade its version shown on documentation to ensure its compatibility. Furthermore, eksworkshop is now pointing to `v2.0.0`, should be upgraded as well.

- https://www.eksworkshop.com/beginner/040_dashboard/dashboard/

Additionally, v2.5.0 having the following bugs that we should avoid it.

- https://github.com/kubernetes/dashboard/issues/6784
- https://github.com/kubernetes/dashboard/issues/6784#issuecomment-1033558501
- https://github.com/kubernetes/dashboard/pull/6800

**_Issue #, if available:_**
- n/a