### PR TITLE
Revert "Update Optimized AMI documentation to reflect we are no longer suppor…"

### DIFF
--- a/doc_source/eks-ami-versions-windows.md
+++ b/doc_source/eks-ami-versions-windows.md
@@ -10,6 +10,44 @@ AMIs are versioned by Kubernetes version and the release date of the AMI in the 
 k8s_major_version.k8s_minor_version-release_date
 ```
 
+## Amazon EKS optimized Windows Server 20H2 Core AMI<a name="eks-ami-versions-windows-20h2-core"></a>
+
+The following tables list the current and previous versions of the Amazon EKS optimized Windows AMI\.
+
+------
+#### [ Kubernetes version 1\.22 ]
+
+
+**Kubernetes version `1.22`**  
+
+| AMI version | `kubelet` version | Docker version | `containerd` version | `csi-proxy` version | 
+| --- | --- | --- | --- | --- | 
+| 1\.22\-2022\.06\.17 | 1\.22\.6 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+| 1\.22\-2022\.05\.16 | 1\.22\.6 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+| 1\.22\-2022\.04\.14 | 1\.22\.6 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+
+------
+#### [ Kubernetes version 1\.21 ]
+
+
+**Kubernetes version `1.21`**  
+
+| AMI version | `kubelet` version | Docker version | `containerd` version | `csi-proxy` version | 
+| --- | --- | --- | --- | --- | 
+| 1\.21\.2022\.06\.17 | 1\.21\.5 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+| 1\.21\.2022\.05\.16 | 1\.21\.5 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+| 1\.21\.2022\.04\.14 | 1\.21\.5 | 20\.10\.9 | 1\.6\.2 | 1\.1\.1 | 
+| 1\.21\.2022\.03\.10 | 1\.21\.5 | 20\.10\.9 | 1\.6\.1 | N/A | 
+| 1\.21\.2022\.02\.23 | 1\.21\.5 | 20\.10\.9 | N/A | N/A | 
+| 1\.21\.2022\.01\.18 | 1\.21\.5 | 20\.10\.9 | N/A | N/A | 
+| 1\.21\.2021\.12\.21 | 1\.21\.5 | 20\.10\.8 | N/A | N/A | 
+| 1\.21\-2021\.11\.10 | 1\.21\.4 | 20\.10\.7 | N/A | N/A | 
+| 1\.21\-2021\.10\.14 | 1\.21\.4 | 20\.10\.7 | N/A | N/A | 
+| 1\.21\-2021\.09\.16 | 1\.21\.2 | 20\.10\.7 | N/A | N/A | 
+| 1\.21\-2021\.08\.12 | 1\.21\.2 | 20\.10\.6 | N/A | N/A | 
+
+------
+
 ## Amazon EKS optimized Windows Server 2019 Core AMI<a name="eks-ami-versions-windows-2019-core"></a>
 
 The following tables list the current and previous versions of the Amazon EKS optimized Windows AMI\.

--- a/doc_source/eks-optimized-windows-ami.md
+++ b/doc_source/eks-optimized-windows-ami.md
@@ -21,7 +21,7 @@ The Amazon EKS\-optimized Windows Server 20H2 Core AMI is being deprecated\. No 
 
 The latest Amazon EKS optimized AMI IDs are in the following tables\. You can also retrieve the IDs with an AWS Systems Manager parameter using different tools\. For more information, see [Retrieving Amazon EKS optimized Windows AMI IDs](retrieve-windows-ami-id.md)\.  
 
-Windows Server 2019 is a Long\-Term Servicing Channel \(LTSC\) release, whereas Versions 20H2 is a Semi\-Annual Channel \(SAC\) release that we no longer support\. For more information, see [Windows Server release information](https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info) in the Microsoft documentation\. Windows Server 20H2 support was added to Kubernetes in version `1.21`\. For more information about Windows OS version support, see [Intro to Windows support in Kubernetes](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/)\.
+Windows Server 2019 is a Long\-Term Servicing Channel \(LTSC\) release, whereas Versions 20H2 is a Semi\-Annual Channel \(SAC\) release\. For more information, see [Windows Server release information](https://docs.microsoft.com/en-us/windows-server/get-started/windows-server-release-info) in the Microsoft documentation\. Windows Server 20H2 support was added to Kubernetes in version `1.21`\. For more information about Windows OS version support, see [Intro to Windows support in Kubernetes](https://kubernetes.io/docs/setup/production-environment/windows/intro-windows-in-kubernetes/)\.
 
 ------
 #### [ 1\.22 ]

--- a/doc_source/retrieve-windows-ami-id.md
+++ b/doc_source/retrieve-windows-ami-id.md
@@ -3,7 +3,8 @@
 You can programmatically retrieve the Amazon Machine Image \(AMI\) ID for Amazon EKS optimized AMIs by querying the AWS Systems Manager Parameter Store API\. This parameter eliminates the need for you to manually look up Amazon EKS optimized AMI IDs\. For more information about the Systems Manager Parameter Store API, see [GetParameter](https://docs.aws.amazon.com/systems-manager/latest/APIReference/API_GetParameter.html)\. Your user account must have the `ssm:GetParameter` IAM permission to retrieve the Amazon EKS optimized AMI metadata\.
 
 You can retrieve the AMI ID with the AWS CLI or the AWS Management Console\.
-+ **AWS CLI** – You can retrieve the image ID of the latest recommended Amazon EKS optimized Windows AMI with the following command by using the sub\-parameter `image_id`\. You can replace `1.22` with any supported Amazon EKS version and can replace `region-code` with an [Amazon EKS supported Region](https://docs.aws.amazon.com/general/latest/gr/eks.html) for which you want the AMI ID\. Replace `Core` with `Full` to see the Windows Server full AMI ID\. 
++ **AWS CLI** – You can retrieve the image ID of the latest recommended Amazon EKS optimized Windows AMI with the following command by using the sub\-parameter `image_id`\. You can replace `1.22` with any supported Amazon EKS version and can replace `region-code` with an [Amazon EKS supported Region](https://docs.aws.amazon.com/general/latest/gr/eks.html) for which you want the AMI ID\. Replace `Core` with `Full` to see the Windows Server full AMI ID\. You can also replace `2019` with `20H2` for the `Core` version only for version `1.21` and later\.
+
   ```
   aws ssm get-parameter --name /aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-1.22/image_id --region region-code --query "Parameter.Value" --output text
   ```
@@ -13,7 +14,8 @@ You can retrieve the AMI ID with the AWS CLI or the AWS Management Console\.
   ```
   ami-1234567890abcdef0
   ```
-+ **AWS Management Console** – You can query for the recommended Amazon EKS optimized AMI ID using a URL\. The URL opens the Amazon EC2 Systems Manager console with the value of the ID for the parameter\. In the following URL, you can replace `1.21` with any supported Amazon EKS version and can replace *`region-code`* with an [Amazon EKS supported Region](https://docs.aws.amazon.com/general/latest/gr/eks.html) for which you want the AMI ID\. Replace `Core` with `Full` to see the Windows Server full AMI ID\. 
++ **AWS Management Console** – You can query for the recommended Amazon EKS optimized AMI ID using a URL\. The URL opens the Amazon EC2 Systems Manager console with the value of the ID for the parameter\. In the following URL, you can replace `1.21` with any supported Amazon EKS version and can replace *`region-code`* with an [Amazon EKS supported Region](https://docs.aws.amazon.com/general/latest/gr/eks.html) for which you want the AMI ID\. Replace `Core` with `Full` to see the Windows Server full AMI ID\. You can also replace `2019` with `20H2` for the `Core` version only for version `1.21` and later\.
+
   ```
   https://console.aws.amazon.com/systems-manager/parameters/aws/service/ami-windows-latest/Windows_Server-2019-English-Core-EKS_Optimized-1.22/image_id/description?region=region-code
   ```


### PR DESCRIPTION
Reverts awsdocs/amazon-eks-user-guide#585

We should wait until at least the August 9th end of support date.