### PR TITLE
Updated incorrect link as mentioned in issue #597 for removing vpc-admission-webhook

### DIFF
--- a/doc_source/windows-support.md
+++ b/doc_source/windows-support.md
@@ -115,7 +115,7 @@ If you enabled Windows support on a cluster that is earlier than a Kubernetes or
    Run the following command\. Replace `region-code` \(only the instance of that text after `/manifests/`\) with the AWS Region that your cluster is in\.
 
    ```
-   kubectl delete -f https://s3.us-west-2.amazonaws.com/amazon-eks//manifests/region-code/vpc-admission-webhook/latest/vpc-admission-webhook-deployment.yaml
+   kubectl delete -f https://s3.us-west-2.amazonaws.com/amazon-eks/manifests/region-code/vpc-admission-webhook/latest/vpc-admission-webhook-deployment.yaml
    ```
 
 ------


### PR DESCRIPTION
*Issue #, if available:* [597](https://github.com/awsdocs/amazon-eks-user-guide/issues/597)

*Description of changes:*
There is a typo in the step 2 -> kubectl on macOS or Windows of the [Removing legacy Windows support from your data plane](https://docs.aws.amazon.com/eks/latest/userguide/windows-support.html#remove-windows-support-data-plane).

The link in the command is malformed.
kubectl delete -f https://s3.us-west-2.amazonaws.com/amazon-eks//manifests/region-code/vpc-admission-webhook/latest/vpc-admission-webhook-deployment.yaml

Fixed the link.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
