### PR TITLE
clarify how to create role for CSI addon

### DIFF
--- a/doc_source/managing-ebs-csi.md
+++ b/doc_source/managing-ebs-csi.md
@@ -31,7 +31,7 @@ You can use `eksctl`, the AWS Management Console, or the AWS CLI to add the Amaz
 #### [ eksctl ]
 
 **To add the Amazon EBS CSI add\-on using `eksctl`**  
-Run the following command\. Replace `my-cluster` with the name of your cluster, `111122223333` with your account ID, and `AmazonEKS_EBS_CSI_DriverRole` with the name of the role created earlier\. If your cluster is in the AWS GovCloud \(US\-East\) or AWS GovCloud \(US\-West\) AWS Regions, then replace `arn:aws:` with `arn:aws-us-gov:`\.
+Run the following command\. Replace `my-cluster` with the name of your cluster, `111122223333` with your account ID, and `AmazonEKS_EBS_CSI_DriverRole` with the name of the [IAM role created earlier\.](https://docs.aws.amazon.com/eks/latest/userguide/csi-iam-role.html) If your cluster is in the AWS GovCloud \(US\-East\) or AWS GovCloud \(US\-West\) AWS Regions, then replace `arn:aws:` with `arn:aws-us-gov:`\.
 
 ```
 eksctl create addon --name aws-ebs-csi-driver --cluster my-cluster --service-account-role-arn arn:aws:iam::111122223333:role/AmazonEKS_EBS_CSI_DriverRole --force


### PR DESCRIPTION
*Issue #, if available:*
n/a

*Description of changes:*
add link to how to create "`AmazonEKS_EBS_CSI_DriverRole` with the name of the role created earlier\."

I was confused as to which role was being referenced here when following the guide. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
