### PR TITLE
Add initial release dates for all major releases

### DIFF
--- a/doc_source/platform-versions.md
+++ b/doc_source/platform-versions.md
@@ -90,7 +90,7 @@ The following admission controllers are enabled for all `1.19` platform versions
 |  `1.19.8`  |  `eks.4`  |  New platform version with security fixes and enhancements\.  |  | 
 |  `1.19.8`  |  `eks.3`  |  New platform version with security fixes and enhancements\.  |  | 
 |  `1.19.6`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.19.6`  |  `eks.1`  |  Initial release of Kubernetes version `1.19` for Amazon EKS\. For more information, see [Kubernetes 1\.19](kubernetes-versions.md#kubernetes-1.19)\.  | 16 Feb, 2021  | 
+|  `1.19.6`  |  `eks.1`  |  Initial release of Kubernetes version `1.19` for Amazon EKS\. For more information, see [Kubernetes 1\.19](kubernetes-versions.md#kubernetes-1.19)\.  | February 16, 2021  | 
 
 ## Kubernetes version `1.18`<a name="platform-versions-1.18"></a>
 
@@ -111,4 +111,4 @@ The following admission controllers are enabled for all `1.18` platform versions
 |  `1.18.9`  |  `eks.4`  | New platform version with security fixes and enhancements\. |  | 
 |  `1.18.9`  |  `eks.3`  |  Includes support for [Amazon EKS add\-ons](eks-add-ons.md) and [Fargate logging](fargate-logging.md)\.  |  | 
 |  `1.18.9`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.18.8`  |  `eks.1`  |  Initial release of Kubernetes version `1.18` for Amazon EKS\. For more information, see [Kubernetes 1\.18](kubernetes-versions.md#kubernetes-1.18)\.  | 13 October, 2020 | 
+|  `1.18.8`  |  `eks.1`  |  Initial release of Kubernetes version `1.18` for Amazon EKS\. For more information, see [Kubernetes 1\.18](kubernetes-versions.md#kubernetes-1.18)\.  | October 13, 2020 | 

--- a/doc_source/platform-versions.md
+++ b/doc_source/platform-versions.md
@@ -55,7 +55,7 @@ The following admission controllers are enabled for all `1.21` platform versions
 |  `1.21.5`  |  `eks.4`  | Version 1\.10\.1\-eksbuild\.1 of the Amazon VPC CNI self\-managed and Amazon EKS add\-on is now the default version deployed\. |  | 
 |  `1.21.2`  |  `eks.3`  | New platform version with support for Windows IPv4 address management on the VPC Resource Controller running on the Kubernetes control plane\. Added the Kubernetes filter directive for Fargate Fluent Bit logging\. |  | 
 |  `1.21.2`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.21.2`  |  `eks.1`  |  Initial release of Kubernetes version `1.21` for Amazon EKS\. For more information, see [Kubernetes 1\.21](kubernetes-versions.md#kubernetes-1.21)\.  |  | 
+|  `1.21.2`  |  `eks.1`  |  Initial release of Kubernetes version `1.21` for Amazon EKS\. For more information, see [Kubernetes 1\.21](kubernetes-versions.md#kubernetes-1.21)\.  | July 20, 2021  | 
 
 ## Kubernetes version `1.20`<a name="platform-versions-1.20"></a>
 
@@ -71,7 +71,7 @@ The following admission controllers are enabled for all `1.20` platform versions
 |  `1.20.11`  |  `eks.4`  |  When using [IAM roles for service accounts](iam-roles-for-service-accounts.md), the AWS Security Token Service Regional endpoint is now used by default instead of the global endpoint\. This change is reverted back to the global endpoint in `eks.5` however\. An updated Fargate scheduler provisions nodes at a significantly higher rate during large deployments\.  |  March 10, 2022  | 
 |  `1.20.11`  |  `eks.3`  |  New platform version with support for Windows `IPv4` address management on the VPC Resource Controller running on the Kubernetes control plane\. Added the Kubernetes filter directive for Fargate Fluent Bit logging\.  |  | 
 |  `1.20.7`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.20.4`  |  `eks.1`  |  Initial release of Kubernetes version `1.20` for Amazon EKS\. For more information, see [Kubernetes 1\.20](kubernetes-versions.md#kubernetes-1.20)\.  |  | 
+|  `1.20.4`  |  `eks.1`  |  Initial release of Kubernetes version `1.20` for Amazon EKS\. For more information, see [Kubernetes 1\.20](kubernetes-versions.md#kubernetes-1.20)\.  | May 18, 2021 | 
 
 ## Kubernetes version `1.19`<a name="platform-versions-1.19"></a>
 
@@ -90,7 +90,7 @@ The following admission controllers are enabled for all `1.19` platform versions
 |  `1.19.8`  |  `eks.4`  |  New platform version with security fixes and enhancements\.  |  | 
 |  `1.19.8`  |  `eks.3`  |  New platform version with security fixes and enhancements\.  |  | 
 |  `1.19.6`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.19.6`  |  `eks.1`  |  Initial release of Kubernetes version `1.19` for Amazon EKS\. For more information, see [Kubernetes 1\.19](kubernetes-versions.md#kubernetes-1.19)\.  |  | 
+|  `1.19.6`  |  `eks.1`  |  Initial release of Kubernetes version `1.19` for Amazon EKS\. For more information, see [Kubernetes 1\.19](kubernetes-versions.md#kubernetes-1.19)\.  | 16 Feb, 2021  | 
 
 ## Kubernetes version `1.18`<a name="platform-versions-1.18"></a>
 
@@ -111,4 +111,4 @@ The following admission controllers are enabled for all `1.18` platform versions
 |  `1.18.9`  |  `eks.4`  | New platform version with security fixes and enhancements\. |  | 
 |  `1.18.9`  |  `eks.3`  |  Includes support for [Amazon EKS add\-ons](eks-add-ons.md) and [Fargate logging](fargate-logging.md)\.  |  | 
 |  `1.18.9`  |  `eks.2`  |  New platform version with security fixes and enhancements\.  |  | 
-|  `1.18.8`  |  `eks.1`  |  Initial release of Kubernetes version `1.18` for Amazon EKS\. For more information, see [Kubernetes 1\.18](kubernetes-versions.md#kubernetes-1.18)\.  |  | 
+|  `1.18.8`  |  `eks.1`  |  Initial release of Kubernetes version `1.18` for Amazon EKS\. For more information, see [Kubernetes 1\.18](kubernetes-versions.md#kubernetes-1.18)\.  | 13 October, 2020 | 


### PR DESCRIPTION
Refs:

- https://aws.amazon.com/blogs/containers/amazon-eks-1-21-released/ 
- https://aws.amazon.com/blogs/containers/amazon-eks-1-20-released/ 
- https://aws.amazon.com/about-aws/whats-new/2021/02/amazon-eks-supports-kubernetes-version-1-19/ 
- https://aws.amazon.com/about-aws/whats-new/2020/10/amazon-eks-supports-kubernetes-version-1-18/

*Description of changes:*: Adds initial release dates for all major Kubernetes versions on the EKS platform versions page.

I tried to track down exact dates for each patch release as well, but couldn't find a good source. It would be nice if these were also added back for archival purposes.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
