### PR TITLE
Update create-kubeconfig.md

### DIFF
--- a/doc_source/create-kubeconfig.md
+++ b/doc_source/create-kubeconfig.md
@@ -174,7 +174,7 @@ The AWS IAM Authenticator for Kubernetes must be installed on your device\. To i
            - "token"
            - "-i"
            - "$cluster_name"
-           # - "- --role-arn"
+           # - "--role"
            # - "arn:aws:iam::$account_id:role/my-role"
          # env:
            # - name: "AWS_PROFILE"


### PR DESCRIPTION
*Description of changes:*

The latest [aws-iam-authenticator](https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/aws-iam-authenticator) doesn't have a flag named `--role-arn`, it should be `--role`
```
Usage:
  aws-iam-authenticator token [flags]

Flags:
      --cache                  Cache the credential on disk until it expires. Uses the aws profile specified by AWS_PROFILE or the default profile.
  -e, --external-id string     External ID to pass when assuming the IAM Role
      --forward-session-name   Enable mapping a federated sessions caller-specified-role-name attribute onto newly assumed sessions. NOTE: Only applicable when a new role is requested via --role
  -h, --help                   help for token
      --region string          AWS region to use for assume role calls
  -r, --role string            Assume an IAM Role ARN before signing this token
  -s, --session-name string    Session name to pass when assuming the IAM Role
      --token-only             Return only the token for use with Bearer token based tools

Global Flags:
  -i, --cluster-id ID                 Specify the cluster ID, a unique-per-cluster identifier for your aws-iam-authenticator installation.
  -c, --config filename               Load configuration from filename
      --feature-gates mapStringBool   A set of key=value pairs that describe feature gates for alpha/experimental features. Options are:
                                      AllAlpha=true|false (ALPHA - default=false)
                                      IAMIdentityMappingCRD=true|false (ALPHA - default=false)
  -l, --log-format string             Specify log format to use when logging to stderr [text or json] (default "text")
```

