### PR TITLE
Update the SGP doc for PSP usage with new User authentication

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -8,7 +8,7 @@ Before deploying security groups for pods, consider the following limits and con
 + Security groups for pods can't be used with Windows nodes\.
 + Security groups for pods can't be used with clusters configured for the `IPv6` family that contain Amazon EC2 nodes\. You can however, use security groups for pods with clusters configured for the `IPv6` family that contain only Fargate nodes\. For more information, see [Tutorial: Assigning `IPv6` addresses to pods and services](cni-ipv6.md)\.
 + Security groups for pods are supported by most [Nitro\-based](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-types.html#ec2-nitro-instances) Amazon EC2 instance families, including the `m5`, `c5`, `r5`, `p3`, `m6g`, `c6g`, and `r6g` instance families\. The `t3` instance family is not supported\. For a complete list of supported instances, see the [https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/pkg/aws/vpc/limits.go](https://github.com/aws/amazon-vpc-resource-controller-k8s/blob/master/pkg/aws/vpc/limits.go) file on Github\. Your nodes must be one of the listed instance types that have `IsTrunkingCompatible: true` in that file\.
-+ If you're also using pod security policies to restrict access to pod mutation, then the `eks-vpc-resource-controller` and `vpc-resource-controller` Kubernetes service accounts must be specified in the Kubernetes `ClusterRoleBinding` for the `role` that your `psp` is assigned to\. If you're using the [default Amazon EKS `psp`, `role`, and `ClusterRoleBinding`](pod-security-policy.md#default-psp), this is the `eks:podsecuritypolicy:authenticated` `ClusterRoleBinding`\. For example, you add the service accounts to the `subjects:` section, as shown in the following example:
++ If you're also using pod security policies to restrict access to pod mutation, then the `eks:vpc-resource-controller` Kubernetes User must be specified in the Kubernetes `ClusterRoleBinding` for the `role` that your `psp` is assigned to\. If you're using the [default Amazon EKS `psp`, `role`, and `ClusterRoleBinding`](pod-security-policy.md#default-psp), this is the `eks:podsecuritypolicy:authenticated` `ClusterRoleBinding`\. For example, you add the User to the `subjects:` section, as shown in the following example:
 
   ```
   ...
@@ -16,8 +16,9 @@ Before deploying security groups for pods, consider the following limits and con
     - kind: Group
       apiGroup: rbac.authorization.k8s.io
       name: system:authenticated
-    - kind: ServiceAccount
-      name: vpc-resource-controller
+    - apiGroup: rbac.authorization.k8s.io
+      kind: User
+      name: eks:vpc-resource-controller
     - kind: ServiceAccount
       name: eks-vpc-resource-controller
   ```


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/amazon-vpc-resource-controller-k8s/issues/134
*Description of changes:*
EKS just switched from service account to User for VPC resource controller. This can be a breaking change if users are using PSP to only allow SA to annotate the pod. We need to call out this change in the doc.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
