### PR TITLE
Update install kubectl instructions to the latest binaries

### DIFF
--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -44,7 +44,7 @@ You must use a `kubectl` version that is within one minor version difference of 
       + Kubernetes `1.21`
 
         ```
-        curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.14/2022-10-31/bin/darwin/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/darwin/amd64/kubectl
         ```
       + Kubernetes `1.20`
 

--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -34,27 +34,22 @@ You must use a `kubectl` version that is within one minor version difference of 
       + Kubernetes `1.23`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/darwin/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/darwin/amd64/kubectl
         ```
       + Kubernetes `1.22`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/darwin/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/darwin/amd64/kubectl
         ```
       + Kubernetes `1.21`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/darwin/amd64/kubectl
+        curl -o kubectl https://amazon-eks.s3-us-west-2.amazonaws.com/1.21.14/2022-10-31/bin/darwin/amd64/kubectl
         ```
       + Kubernetes `1.20`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/darwin/amd64/kubectl
-        ```
-      + Kubernetes `1.19`
-
-        ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/darwin/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/darwin/amd64/kubectl
         ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
@@ -63,27 +58,22 @@ You must use a `kubectl` version that is within one minor version difference of 
          + Kubernetes `1.23`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/darwin/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/darwin/amd64/kubectl.sha256
            ```
          + Kubernetes `1.22`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/darwin/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/darwin/amd64/kubectl.sha256
            ```
          + Kubernetes `1.21`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/darwin/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/darwin/amd64/kubectl.sha256
            ```
          + Kubernetes `1.20`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/darwin/amd64/kubectl.sha256
-           ```
-         + Kubernetes `1.19`
-
-           ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/darwin/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/darwin/amd64/kubectl.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.
@@ -127,47 +117,38 @@ You must use a `kubectl` version that is within one minor version difference of 
       + Kubernetes `1.23`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/linux/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/amd64/kubectl
         ```
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/linux/arm64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/arm64/kubectl
         ```
       + Kubernetes `1.22`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/linux/amd64/kubectl
         ```
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/arm64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/linux/arm64/kubectl
         ```
       + Kubernetes `1.21`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/linux/amd64/kubectl
         ```
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/arm64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/linux/arm64/kubectl
         ```
       + Kubernetes `1.20`
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/linux/amd64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/amd64/kubectl
         ```
 
         ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/linux/arm64/kubectl
-        ```
-      + Kubernetes `1.19`
-
-        ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/amd64/kubectl
-        ```
-
-        ```
-        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/arm64/kubectl
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/arm64/kubectl
         ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
@@ -176,47 +157,38 @@ You must use a `kubectl` version that is within one minor version difference of 
          + Kubernetes `1.23`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/linux/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/amd64/kubectl.sha256
            ```
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/linux/arm64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/linux/arm64/kubectl.sha256
            ```
          + Kubernetes `1.22`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/linux/amd64/kubectl.sha256
            ```
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/linux/arm64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/linux/arm64/kubectl.sha256
            ```
          + Kubernetes `1.21`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/linux/amd64/kubectl.sha256
            ```
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/linux/arm64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/linux/arm64/kubectl.sha256
            ```
          + Kubernetes `1.20`
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/linux/amd64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/amd64/kubectl.sha256
            ```
 
            ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/linux/arm64/kubectl.sha256
-           ```
-         + Kubernetes `1.19`
-
-           ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/amd64/kubectl.sha256
-           ```
-
-           ```
-           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/arm64/kubectl.sha256
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/arm64/kubectl.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.
@@ -264,27 +236,22 @@ This step assumes you are using the Bash shell; if you are using another shell, 
       + Kubernetes `1.23`
 
         ```
-        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/windows/amd64/kubectl.exe
+        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/windows/amd64/kubectl.exe
         ```
       + Kubernetes `1.22`
 
         ```
-        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/windows/amd64/kubectl.exe
+        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/windows/amd64/kubectl.exe
         ```
       + Kubernetes `1.21`
 
         ```
-        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/windows/amd64/kubectl.exe
+        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/windows/amd64/kubectl.exe
         ```
       + Kubernetes `1.20`
 
         ```
-        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/windows/amd64/kubectl.exe
-        ```
-      + Kubernetes `1.19`
-
-        ```
-        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/windows/amd64/kubectl.exe
+        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/windows/amd64/kubectl.exe
         ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
@@ -293,27 +260,22 @@ This step assumes you are using the Bash shell; if you are using another shell, 
          + Kubernetes `1.23`
 
            ```
-           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.7/2022-06-29/bin/windows/amd64/kubectl.exe.sha256
+           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.23.13/2022-10-31/bin/windows/amd64/kubectl.exe.sha256
            ```
          + Kubernetes `1.22`
 
            ```
-           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.6/2022-03-09/bin/windows/amd64/kubectl.exe.sha256
+           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.22.15/2022-10-31/bin/windows/amd64/kubectl.exe.sha256
            ```
          + Kubernetes `1.21`
 
            ```
-           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.2/2021-07-05/bin/windows/amd64/kubectl.exe.sha256
+           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.21.14/2022-10-31/bin/windows/amd64/kubectl.exe.sha256
            ```
          + Kubernetes `1.20`
 
            ```
-           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.4/2021-04-12/bin/windows/amd64/kubectl.exe.sha256
-           ```
-         + Kubernetes `1.19`
-
-           ```
-           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/windows/amd64/kubectl.exe.sha256
+           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/windows/amd64/kubectl.exe.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.

--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -51,6 +51,11 @@ You must use a `kubectl` version that is within one minor version difference of 
         ```
         curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/darwin/amd64/kubectl
         ```
+      + Kubernetes `1.19`
+
+        ```
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/darwin/amd64/kubectl
+        ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
 
@@ -74,6 +79,11 @@ You must use a `kubectl` version that is within one minor version difference of 
 
            ```
            curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/darwin/amd64/kubectl.sha256
+           ```
+         + Kubernetes `1.19`
+
+           ```
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/darwin/amd64/kubectl.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.
@@ -150,6 +160,15 @@ You must use a `kubectl` version that is within one minor version difference of 
         ```
         curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/arm64/kubectl
         ```
+      + Kubernetes `1.19`
+
+        ```
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/amd64/kubectl
+        ```
+
+        ```
+        curl -o kubectl https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/arm64/kubectl
+        ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
 
@@ -189,6 +208,15 @@ You must use a `kubectl` version that is within one minor version difference of 
 
            ```
            curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/linux/arm64/kubectl.sha256
+           ```
+         + Kubernetes `1.19`
+
+           ```
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/amd64/kubectl.sha256
+           ```
+
+           ```
+           curl -o kubectl.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/linux/arm64/kubectl.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.
@@ -253,6 +281,11 @@ This step assumes you are using the Bash shell; if you are using another shell, 
         ```
         curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/windows/amd64/kubectl.exe
         ```
+      + Kubernetes `1.19`
+
+        ```
+        curl -o kubectl.exe https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/windows/amd64/kubectl.exe
+        ```
 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` sum for your binary\.
 
@@ -276,6 +309,11 @@ This step assumes you are using the Bash shell; if you are using another shell, 
 
            ```
            curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.20.15/2022-10-31/bin/windows/amd64/kubectl.exe.sha256
+           ```
+         + Kubernetes `1.19`
+
+           ```
+           curl -o kubectl.exe.sha256 https://s3.us-west-2.amazonaws.com/amazon-eks/1.19.6/2021-01-05/bin/windows/amd64/kubectl.exe.sha256
            ```
 
       1. Check the `SHA-256` sum for your downloaded binary\.


### PR DESCRIPTION
*Description of changes:*
We recently updated binaries, so updating versions to reflect that and remove 1.19 since it's deprecated.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
