### PR TITLE
Update managing-vpc-cni.md

### DIFF
--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -265,6 +265,7 @@ Versions are specified as `major-version.minor-version.patch-version`
 You should only update one minor version at a time\. For example, if your current minor version is `1.10` and you want to update to `1.12`, then you should update to `1.11` first, then update to `1.12`\.
 All versions work with all Amazon EKS supported Kubernetes versions, though not all features of each release work with all Kubernetes versions\. When using different Amazon EKS features, if a specific version of the add\-on is required, then it's noted in the feature documentation\.
 We recommend that you update to version `1.12.0`, though you can update to any [release version](https://github.com/aws/amazon-vpc-cni-k8s/releases), if necessary\.
+If you need to install a VPC CNI bellow `1.12.0` with a helm chart, an `aws-vpc-cni` Helm chart with version bellow `v1.2.0` should be used\.
 
 **To update the self\-managed add\-on**
 


### PR DESCRIPTION
Updated Important banner based on aws-vpc-cni helm chart pull.

*Issue #, if available:*
https://github.com/aws/eks-charts/pull/836

*Description of changes:*
Updated banner, to include changes of the updated aws-vpc-cni helm chart.

If updating to a cni version lower than 1.12.0 without specifying the helm chart version, will break the cni as the latest helm chart is used which removes the dockershim or cri volume mount.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
