### PR TITLE
Added the missing `"` for the `--query` param

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -53,7 +53,7 @@ When you want to deploy custom networking to your production cluster, skip to [S
 
       ```
       aws cloudformation describe-stacks --region $region_code --stack-name my-eks-custom-networking-vpc \
-          --query Stacks[].StackStatus --output text
+          --query "Stacks[].StackStatus" --output text
       ```
 
       Don't continue to the next step until the output of the command is `CREATE_COMPLETE`\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Without the double quotes, the command failed with: no matches found: Stacks[].StackStatus

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
