### PR TITLE
Adding the missing EC2 permission

### DIFF
--- a/doc_source/autoscaling.md
+++ b/doc_source/autoscaling.md
@@ -62,7 +62,8 @@ Create an IAM policy that grants the permissions that the Cluster Autoscaler req
                       "autoscaling:DescribeAutoScalingGroups",
                       "ec2:DescribeLaunchTemplateVersions",
                       "autoscaling:DescribeTags",
-                      "autoscaling:DescribeLaunchConfigurations"
+                      "autoscaling:DescribeLaunchConfigurations",
+                      "ec2:DescribeInstanceTypes"
                   ],
                   "Resource": "*"
               }


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

New Cluster Autoscaler versions need to have the ec2:DescribeInstanceTypes permission to allow the Pod to start with success.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
