### PR TITLE
docs: Mention Node sdk v2 and .NET caveat

### DIFF
--- a/doc_source/iam-roles-for-service-accounts-minimum-sdk.md
+++ b/doc_source/iam-roles-for-service-accounts-minimum-sdk.md
@@ -7,10 +7,13 @@ The containers in your pods must use an AWS SDK version that supports assuming a
 + Python \(Boto3\) – [1\.9\.220](https://github.com/boto/boto3/releases/tag/1.9.220)
 + Python \(botocore\) – [1\.12\.200](https://github.com/boto/botocore/releases/tag/1.12.200)
 + AWS CLI – [1\.16\.232](https://github.com/aws/aws-cli/releases/tag/1.16.232)
-+ Node – [3\.27\.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.27.0)
++ Node
+  + [2\.525\.0](https://github.com/aws/aws-sdk-js/releases/tag/v2.525.0)
+  + [3\.27\.0](https://github.com/aws/aws-sdk-js-v3/releases/tag/v3.27.0)
 + Ruby – [3\.58\.0](https://github.com/aws/aws-sdk-ruby/blob/version-3/gems/aws-sdk-core/CHANGELOG.md#3580-2019-07-01)
 + C\+\+ – [1\.7\.174](https://github.com/aws/aws-sdk-cpp/releases/tag/1.7.174)
 + \.NET – [3\.3\.659\.1](https://github.com/aws/aws-sdk-net/releases/tag/3.3.659.1)
+  + You must also include `AWSSDK.SecurityToken` to make use of IRSA in EKS.
 + PHP – [3\.110\.7](https://github.com/aws/aws-sdk-php/releases/tag/3.110.7)
 
 Many popular Kubernetes add\-ons, such as the [Cluster Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/cluster-autoscaler) and the [Installing the AWS Load Balancer Controller add\-on](aws-load-balancer-controller.md), support IAM roles for service accounts\. The [https://github.com/aws/amazon-vpc-cni-k8s](https://github.com/aws/amazon-vpc-cni-k8s) also supports IAM roles for service accounts\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- This mentions that the Node v2 sdk, which is still being updated and maintained will also work with IRSA if the version is new enough.
- This adds a caveat to the .NET SDK line, since you must include the SecurityToken binary or file to make use of IRSA using .NET. More info in this [PR](https://github.com/aws-samples/one-observability-demo/pull/22) and this [PR](https://github.com/aws/aws-dotnet-extensions-configuration/pull/73/files)

It's understandable if you'd rather not include these, but this info would have helped us massively had we known it beforehand, so figured it might help others. Either way, thanks in advance for your review!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
