### PR TITLE
Clarify comment on pod to pod communication

### DIFF
--- a/doc_source/security-groups-for-pods.md
+++ b/doc_source/security-groups-for-pods.md
@@ -97,7 +97,7 @@ If you're using `1.11.0` or later of the Amazon VPC CNI plugin for Kubernetes ad
    kubectl set env daemonset aws-node -n kube-system POD_SECURITY_GROUP_ENFORCING_MODE=standard
    ```
 **Important**  
-Pod security group rules aren't applied to traffic between pods or between pods and services, such as `kubelet` or `nodeLocalDNS`, that are on the same node\.
+Pod security group rules are not applied to traffic between pods or between pods and services, such as `kubelet` or `nodeLocalDNS`, that are on the same node\. Note that pods using different security groups on the same node cannot communicate because they are configured in different subnets, and routing is disabled between these subnets\. 
 Outbound traffic from pods to addresses outside of the VPC is network address translated to the IP address of the instance's primary network interface \(unless you've also set `AWS_VPC_K8S_CNI_EXTERNALSNAT=true`\)\. For this traffic, the rules in the security groups for the primary network interface are used, rather than the rules in the pod's security groups\.
 For this setting to apply to existing pods, you must restart the pods or the nodes that the pods are running on\.
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awsdocs/amazon-eks-user-guide/issues/634

*Description of changes:*
Clarify comment on pod to pod communication on the same node. Pods in different security groups cannot communicate because they are in different VLANs, and routing between those VLANs is disabled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
