### PR TITLE
docs: Update recommended version of eks add-on for v1.24

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -9,7 +9,7 @@
 
 | Image type | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
+| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.2 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
 | kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.8\-minimal\-eksbuild\.2 | v1\.22\.11\-minimal\-eksbuild\.2 | v1\.21\.14\-minimal\-eksbuild\.2 | v1\.20\.15\-minimal\-eksbuild\.3 | v1\.19\.16\-minimal\-eksbuild\.3 | 
 
 You can check the current version of your `kube-proxy` container\-image with the following command\.

--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -11,7 +11,7 @@ The plugin is an open\-source project that is maintained on GitHub\. We recommen
 
 |  | 1\.24 | 1\.23 | 1\.22 | 1\.21 | 1\.20 | 1\.19 | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| Add\-on version | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 
+| Add\-on version | 1\.12\.0\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 1\.11\.4\-eksbuild\.1 | 
 
 If you created a `1.18` or later cluster using the AWS Management Console, then Amazon EKS installed the plugin for you as an Amazon EKS add\-on\. If you originally created a `1.17` or earlier cluster using any tool, or you created a `1.18` or later cluster using any tool other than the AWS Management Console, then Amazon EKS installed the plugin as a self\-managed add\-on for you\. You can migrate the self\-managed add\-on to the Amazon EKS add\-on using the procedure in [Creating the Amazon VPC CNI Amazon EKS add\-on](#adding-vpc-cni-eks-add-on)\. If you have a cluster that you've already added the Amazon VPC CNI plugin for Kubernetes add\-on to, you can manage it using the procedures in the [Updating the Amazon VPC CNI plugin for Kubernetes add\-on](#updating-vpc-cni-eks-add-on) and [Deleting the Amazon VPC CNI plugin for Kubernetes add\-on](#removing-vpc-cni-eks-add-on) sections\. For more information about Amazon EKS add\-ons, see [Amazon EKS add\-ons](eks-add-ons.md)\.
 


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Hi,
This is the update about the recommended version of EKS add-on for v1.24 from kube-proxy and vpc-cni.
I found the inconsistent add-on versions from docs via the following `eksctl`:
 ```
 eksctl get addon --name vpc-cni --cluster my-cluster
 eksctl get addon --name kube-proxy --cluster my-cluster
 ```
The recommended versions from the output are:
```
vpc-cni	        v1.12.0-eksbuild.1
kube-proxy	v1.24.7-eksbuild.2
```

Please help to check them.

Thank you!

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
