### PR TITLE
corrected ebs csi driver managed addon wording

### DIFF
--- a/doc_source/managing-ebs-csi.md
+++ b/doc_source/managing-ebs-csi.md
@@ -22,7 +22,7 @@ To use the snapshot functionality of the Amazon EBS CSI driver, you must install
 For more information, see [CSI Snapshotter](https://github.com/kubernetes-csi/external-snapshotter) on GitHub\.
 
 **Note**  
-The Amazon EBS CSI driver version 1\.12 or higher has support for Windows Server 2022, but it hasn't been released as an add\-on\. To enable support, you can install the driver using Helm\. Refer to the [`aws-ebs-csi-driver` Windows `README.md`](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/windows) on GitHub\.
+The Amazon EBS CSI driver version 1\.12 or higher has support for Windows Server 2022 and it has been released as an Amazon EKS Managed add\-on\. To enable support, you can install the driver using Helm\. Refer to the [`aws-ebs-csi-driver` Windows `README.md`](https://github.com/kubernetes-sigs/aws-ebs-csi-driver/tree/master/examples/kubernetes/windows) on GitHub\.
 
 ## Adding the Amazon EBS CSI add\-on<a name="adding-ebs-csi-eks-add-on"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
EBS CSI driver supports windows worker nodes as managed Addon. Updated the documentation.

Ref blog: https://aws.amazon.com/blogs/containers/amazon-ebs-csi-driver-is-now-generally-available-in-amazon-eks-add-ons/ 

Also, I tested it in my lab environment.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
