### PR TITLE
fix typo in connector-grant-access.md

### DIFF
--- a/doc_source/connector-grant-access.md
+++ b/doc_source/connector-grant-access.md
@@ -6,7 +6,7 @@ Grant additional IAM users access to the Amazon EKS console to view information 
 
 The IAM user or role that you use to access the AWS Management Console must meet the following requirements\.
 + It has the `eks:AccessKubernetesApi` permission\.
-+ The Amazon EKS Connector Service account can impersonate the IAM or role in the cluster\. This allows the eks\-connector to map the IAM user or role to a Kubernetes user\.
++ The Amazon EKS Connector Service account can impersonate the IAM user or role in the cluster\. This allows the eks\-connector to map the IAM user or role to a Kubernetes user\.
 
 **To create and apply the Amazon EKS Connector cluster role**
 


### PR DESCRIPTION
missing word in prerequisites section

*Issue #, if available:* n/a

*Description of changes:* Add missing word in `Prerequisites` section of `connector-grant-access.md`


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
