### PR TITLE
update the latest versions of managing-kube-proxy

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -10,7 +10,7 @@
 | Image type | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
 | --- | --- | --- | --- | --- | --- | --- | 
 | kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
-| kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.13\-minimal\-eksbuild\.2 | v1\.22\.11\-minimal\-eksbuild\.2 | v1\.21\.14\-minimal\-eksbuild\.2 | v1\.20\.15\-minimal\-eksbuild\.3 | v1\.19\.16\-minimal\-eksbuild\.3 | 
+| kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.13\-minimal\-eksbuild\.2 | v1\.22\.16\-minimal\-eksbuild\.3 | v1\.21\.14\-minimal\-eksbuild\.4 | v1\.20\.15\-minimal\-eksbuild\.4 | v1\.19\.16\-minimal\-eksbuild\.3 | 
 
 You can see which version is installed on your cluster with the following command\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Update the Latest available kube-proxy container image version for each Amazon EKS cluster version since the information is out of date. 

v1.20.15-minimal-eksbuild.3 -> v1.20.15-minimal-eksbuild.4
v1.21.14-minimal-eksbuild.2 -> v1.21.14-minimal-eksbuild.4
v1.22.11-minimal-eksbuild.2 -> v1.22.16-minimal-eksbuild.3 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
