### PR TITLE
Remove the versions of managing-kube-proxy we don't support anymore.

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -9,8 +9,8 @@
 
 | Image type | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
-| kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.13\-minimal\-eksbuild\.2 | v1\.22\.16\-minimal\-eksbuild\.3 | v1\.21\.14\-minimal\-eksbuild\.4 | v1\.20\.15\-minimal\-eksbuild\.4 | v1\.19\.16\-minimal\-eksbuild\.3 | 
+| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | 
+| kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.13\-minimal\-eksbuild\.2 | v1\.22\.16\-minimal\-eksbuild\.3 | v1\.21\.14\-minimal\-eksbuild\.4 | 
 
 You can see which version is installed on your cluster with the following command\.
 

--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -7,8 +7,8 @@
 
 **Latest available `kube-proxy` container image version for each Amazon EKS cluster version**  
 
-| Image type | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
-| --- | --- | --- | --- | --- | --- | --- | 
+| Image type | `1.24` | `1.23` | `1.22` | `1.21` |  
+| --- | --- | --- | --- | --- | 
 | kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | 
 | kube\-proxy \(minimal type\) | v1\.24\.7\-minimal\-eksbuild\.2 | v1\.23\.13\-minimal\-eksbuild\.2 | v1\.22\.16\-minimal\-eksbuild\.3 | v1\.21\.14\-minimal\-eksbuild\.4 | 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removing the kube-proxy add-on version we don't support anymore.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
