### PR TITLE
Fix efs-csi driver installation instructions

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -191,7 +191,7 @@ If you want to download the image with a manifest, we recommend first trying the
 
    ```
    kubectl kustomize \
-       "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/?ref=release-1.4" > private-ecr-driver.yaml
+       "github.com/kubernetes-sigs/aws-efs-csi-driver/deploy/kubernetes/overlays/stable/ecr/?ref=release-1.4" > private-ecr-driver.yaml
    ```
 **Note**  
 If you encounter an issue that you aren't able to resolve by adding IAM permissions, try the "Manifest \(public registry\)" steps instead\.


### PR DESCRIPTION
This PR is a minor fix in the efs-csi driver installation instructions with private repository mode.

*Issue #, if available:*
No issue

*Description of changes:*
The URL when running kustomize in a private repository setup is incorrect: the kustomize private setup is in the /ecr directory. This change fix the corresponding command line.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
