### PR TITLE
Remove duplicate step in EBS CSI driver docs

### DIFF
--- a/doc_source/csi-iam-role.md
+++ b/doc_source/csi-iam-role.md
@@ -345,12 +345,6 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
           eks.amazonaws.com/role-arn=arn:aws:iam::111122223333:role/AmazonEKS_EBS_CSI_DriverRole
       ```
 
-   1. Restart the `ebs-csi-controller` deployment for the annotation to take effect\.
-
-      ```
-      kubectl rollout restart deployment ebs-csi-controller -n kube-system
-      ```
-
 1. Restart the `ebs-csi-controller` deployment for the annotation to take effect\.
 
    ```


### PR DESCRIPTION
Remove duplicate step (**5.b** and **6**) from the EBS CSI drivers documentation


![image](https://user-images.githubusercontent.com/13874084/211930283-c71d1331-7f17-4790-83a5-d2b38d60338b.png)

