### PR TITLE
Update recommended VPC CNI version to v1.12.1

### DIFF
--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -11,7 +11,7 @@ The plugin is an open\-source project that is maintained on GitHub\. We recommen
 
 |  | 1\.24 | 1\.23 | 1\.22 | 1\.21 | 1\.20 | 1\.19 | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| Add\-on version | 1\.12\.0\-eksbuild\.1 | 1\.12\.0\-eksbuild\.1 | 1\.12\.0\-eksbuild\.1 | 1\.12\.0\-eksbuild\.1 | 1\.12\.0\-eksbuild\.1 | 1\.12\.0\-eksbuild\.1 | 
+| Add\-on version | 1\.12\.1\-eksbuild\.1 | 1\.12\.1\-eksbuild\.1 | 1\.12\.1\-eksbuild\.1 | 1\.12\.1\-eksbuild\.1 | 1\.12\.1\-eksbuild\.1 | 1\.12\.1\-eksbuild\.1 | 
 
 You can see which version is installed on your cluster with the following command\.
 


### PR DESCRIPTION
Update recommended VPC CNI version to v1.12.1-eksbuild.1

*Issue #, if available:*
N/A

*Description of changes:*
Now that VPC CNI version v1.12.1 is released, update recommended version for deployers.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
