### PR TITLE
escaping special character

### DIFF
--- a/doc_source/cni-custom-network.md
+++ b/doc_source/cni-custom-network.md
@@ -53,7 +53,7 @@ The following procedures help you create a test VPC and cluster and configure cu
       The AWS CloudFormation stack takes a few minutes to create\. To check on the stack's deployment status, run the following command\.
 
       ```
-      aws cloudformation describe-stacks --stack-name my-eks-custom-networking-vpc --query Stacks[].StackStatus --output text
+      aws cloudformation describe-stacks --stack-name my-eks-custom-networking-vpc --query Stacks\[\].StackStatus --output text
       ```
 
       Don't continue to the next step until the output of the command is `CREATE_COMPLETE`\.


### PR DESCRIPTION
current cmd result in "zsh: no matches found: Stacks[].StackStatus" on mac.

aws cloudformation describe-stacks --stack-name my-eks-custom-networking-vpc --query Stacks\[\].StackStatus --output text  fixes the issue.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
