### PR TITLE
Update kube-proxy v1.24.7 the correct image

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -14,7 +14,7 @@ There are two types of the `kube-proxy` container image available for each Amazo
 
 | Image type | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
 | --- | --- | --- | --- | --- | --- | --- | 
-| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.1 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
+| kube\-proxy \(default type\) | v1\.24\.7\-eksbuild\.2 | v1\.23\.8\-eksbuild\.2 | v1\.22\.11\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | v1\.19\.16\-eksbuild\.2 | 
 | kube\-proxy \(minimal type\) | v1\.24\.9\-minimal\-eksbuild\.1 | v1\.23\.15\-minimal\-eksbuild\.1 | v1\.22\.16\-minimal\-eksbuild\.3 | v1\.21\.14\-minimal\-eksbuild\.4 | v1\.20\.15\-minimal\-eksbuild\.4 | v1\.19\.16\-minimal\-eksbuild\.3 | 
 
 **Important**  


### PR DESCRIPTION
*Description of changes:*

Update kube-proxy v1.24.7 the correct image `v1\.24\.7\-eksbuild\.2`

![2023-01-31_10-23](https://user-images.githubusercontent.com/332330/215894418-9520b4be-565d-4064-8eb4-bbc268677736.png)

*Issue #, if available:*

Customer reported referencing the above screenshot that kube-proxy listed in *addons dropdown in console* was `v1.24.7-eksbuild.2`, while the docs mentioned in v1.24.7-eksbuild.1


We are making this consistent first.  If we want to update to mention of latest in the docs to  v1.24.9, as it is already available in the console, I will follow up with separate PR.

--- 



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
