### PR TITLE
Fetch load balancer controller logs from all pods

### DIFF
--- a/doc_source/alb-ingress.md
+++ b/doc_source/alb-ingress.md
@@ -163,7 +163,7 @@ If you created the load balancer in a private subnet, the value under `ADDRESS` 
 If your ingress wasn't successfully created after several minutes, run the following command to view the AWS Load Balancer Controller logs\. These logs might contain error messages that you can use to diagnose issues with your deployment\.  
 
    ```
-   kubectl logs -n kube-system deployment.apps/aws-load-balancer-controller
+   kubectl logs -f -n kube-system -l app.kubernetes.io/instance=aws-load-balancer-controller
    ```
 
 1. If you deployed to a public subnet, open a browser and navigate to the `ADDRESS` URL from the previous command output to see the sample application\. If you don't see anything, refresh your browser and try again\. If you deployed to a private subnet, then you'll need to view the page from a device within your VPC, such as a bastion host\. For more information, see [Linux Bastion Hosts on AWS](http://aws.amazon.com/quickstart/architecture/linux-bastion/)\.  


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*
Previous command may fetch logs from only 1 out of all replicas for AWS Load balancer controller lead to incomplete information

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
