### PR TITLE
Fixed Latest available self-managed CoreDNS container image version f…

### DIFF
--- a/doc_source/managing-coredns.md
+++ b/doc_source/managing-coredns.md
@@ -12,7 +12,7 @@ The following table lists the latest version of the CoreDNS container image avai
 
 | Kubernetes version | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | `1.19` | 
 | --- | --- | --- | --- | --- | --- | --- | 
-|  | v1\.8\.7\-eksbuild\.3 | v1\.8\.7\-eksbuild\.3 | v1\.8\.7\-eksbuild\.1 | v1\.8\.4\-eksbuild\.2 | v1\.8\.3\-eksbuild\.1 | 1\.8\.0 | 
+|  | v1\.8\.7\-eksbuild\.3 | v1\.8\.7\-eksbuild\.3 | v1\.8\.7\-eksbuild\.3 | v1\.8\.4\-eksbuild\.2 | v1\.8\.3\-eksbuild\.1 | 1\.8\.0 | 
 
 **Important**  
 When you [update an Amazon EKS add\-on type](managing-add-ons.md#updating-an-add-on), you specify a valid Amazon EKS add\-on version, which might not be a version listed in this table\. This is because [Amazon EKS add\-on](eks-add-ons.md#add-ons-coredns) versions don't always match container image versions specified when updating the self\-managed type of this add\-on\. When you update the self\-managed type of this add\-on, you specify a valid container image version listed in this table\. 


### PR DESCRIPTION
…or each Amazon EKS cluster version.

*Issue #, if available:*

*Description of changes:*
To solve the ticket cut by customer about the confusion in the core-dns add-on image version supported in kubernetes-version 1.22. Fixed the table in Updating the CoreDNS self-managed add-on.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
