### PR TITLE
New supported regions for EKS local clusters on Outposts

### DIFF
--- a/doc_source/eks-outposts-local-cluster-overview.md
+++ b/doc_source/eks-outposts-local-cluster-overview.md
@@ -7,7 +7,7 @@ You can use local clusters to run your entire Amazon EKS cluster locally on AWS 
 Local clusters are generally available for use with Outposts racks\.<a name="outposts-control-plane-supported-regions"></a>
 
 **Supported AWS Regions**  
-You can create local clusters in the following AWS Regions: US East \(N\. Virginia\), US East \(Ohio\), US West \(N\. California\), US West \(Oregon\), Asia Pacific \(Tokyo\), Asia Pacific \(Seoul\), Europe \(Frankfurt\), Europe \(London\), Middle East \(Bahrain\), and South America \(São Paulo\)\. For detailed information about supported features, see [Comparing the deployment options](eks-outposts.md#outposts-overview-comparing-deployment-options)\.
+You can create local clusters in the following AWS Regions: US East \(N\. Virginia\), US East \(Ohio\), US West \(N\. California\), US West \(Oregon\), Asia Pacific \(Seoul\), Asia Pacific \(Singapore\), Asia Pacific \(Tokyo\), Canada \(Central\), Europe \(Frankfurt\), Europe \(London\), Middle East \(Bahrain\), and South America \(São Paulo\). For detailed information about supported features, see [Comparing the deployment options](eks-outposts.md#outposts-overview-comparing-deployment-options)\.
 
 **Topics**
 + [Creating a local cluster on an Outpost](eks-outposts-local-cluster-create.md)

--- a/doc_source/eks-outposts.md
+++ b/doc_source/eks-outposts.md
@@ -27,7 +27,7 @@ The following table compares the differences between the two options\.
 | --- | --- | --- | 
 |  Kubernetes control plane location  | AWS Region | Outpost | 
 |  Kubernetes control plane account  | AWS account | Your account | 
-| Regional availability | See [Service endpoints](https://docs.aws.amazon.com/general/latest/gr/eks.html#eks_region) | US East \(N\. Virginia\), US East \(Ohio\), US West \(N\. California\), US West \(Oregon\), Asia Pacific \(Tokyo\), Asia Pacific \(Seoul\), Europe \(Frankfurt\), Europe \(London\), Middle East \(Bahrain\), and South America \(São Paulo\) | 
+| Regional availability | See [Service endpoints](https://docs.aws.amazon.com/general/latest/gr/eks.html#eks_region) | US East \(N\. Virginia\), US East \(Ohio\), US West \(N\. California\), US West \(Oregon\), Asia Pacific \(Seoul\), Asia Pacific \(Singapore\), Asia Pacific \(Tokyo\), Canada \(Central\), Europe \(Frankfurt\), Europe \(London\), Middle East \(Bahrain\), and South America \(São Paulo\) | 
 | Kubernetes minor versions | `1.21` and later [supported Amazon EKS versions](kubernetes-versions.md)\. | 1\.21 and later [supported Amazon EKS versions](kubernetes-versions.md)\. | 
 | Platform versions | See [Amazon EKS platform versions](platform-versions.md) | See [Amazon EKS local cluster platform versions](eks-outposts-platform-versions.md) | 
 | Outpost form factors | Outpost racks | Outpost racks | 


### PR DESCRIPTION
*Description of Changes*

Add Asia Pacific (Singapore) and Canada (Central) as supported regions for EKS local clusters on Outposts


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
