### PR TITLE
fix: formatting and removes ambiguity in answer

### DIFF
--- a/doc_source/ebs-csi-migration-faq.md
+++ b/doc_source/ebs-csi-migration-faq.md
@@ -36,7 +36,7 @@ Yes, as long as the [Amazon EBS CSI driver](ebs-csi.md) is installed\.
 
 ## Will the `kubernetes.io/aws-ebs` `StorageClass` provisioner ever be removed from Amazon EKS?<a name="csi-migration-faq-aws-ebs-provisioner"></a>
 
-No\. The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\. These resources are no longer supported and there are no plans to remove them\.
+These resources are no longer supported, but there are no plans to remove them\. The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\.
 
 ## How do I install the Amazon EBS CSI driver?<a name="csi-migration-faq-ebs-csi-driver"></a>
 

--- a/doc_source/ebs-csi-migration-faq.md
+++ b/doc_source/ebs-csi-migration-faq.md
@@ -24,19 +24,19 @@ To help you migrate from the in\-tree plugin to CSI drivers, the `CSIMigration` 
 **Note**  
 The in\-tree `StorageClass` provisioner is named `kubernetes.io/aws-ebs`\. The Amazon EBS CSI `StorageClass` provisioner is named `ebs.csi.aws.com`\.
 
-## Can I mount `kubernetes.io/aws-ebs``StorageClass` volumes in version `1.23` and later clusters?<a name="csi-migration-faq-mounting-volumes"></a>
+## Can I mount `kubernetes.io/aws-ebs` `StorageClass` volumes in version `1.23` and later clusters?<a name="csi-migration-faq-mounting-volumes"></a>
 
 Yes, as long as the [Amazon EBS CSI driver](ebs-csi.md) is installed\. For newly created version `1.23` and later clusters, we recommend installing the Amazon EBS CSI driver as part of your cluster creation process\. We also recommend only using `StorageClasses` based on the `ebs.csi.aws.com` provisioner\.
 
 If you've updated your cluster control plane to version `1.23` and haven't yet updated your nodes to `1.23`, then the `CSIMigration` and `CSIMigrationAWS` `kubelet` flags aren't enabled\. In this case, the in\-tree driver is used to mount `kubernetes.io/aws-ebs` based volumes\. The Amazon EBS CSI driver must still be installed however, to ensure that pods using `kubernetes.io/aws-ebs` based volumes can be scheduled\. The driver is also required for other volume operations to succeed\. 
 
-## Can I provision `kubernetes.io/aws-ebs``StorageClass` volumes on Amazon EKS `1.23` and later clusters?<a name="csi-migration-faq-aws-ebs-volumes"></a>
+## Can I provision `kubernetes.io/aws-ebs` `StorageClass` volumes on Amazon EKS `1.23` and later clusters?<a name="csi-migration-faq-aws-ebs-volumes"></a>
 
 Yes, as long as the [Amazon EBS CSI driver](ebs-csi.md) is installed\.
 
-## Will the `kubernetes.io/aws-ebs``StorageClass` provisioner ever be removed from Amazon EKS?<a name="csi-migration-faq-aws-ebs-provisioner"></a>
+## Will the `kubernetes.io/aws-ebs` `StorageClass` provisioner ever be removed from Amazon EKS?<a name="csi-migration-faq-aws-ebs-provisioner"></a>
 
-No\. The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\. These resources are no longer supported, but there are no plans to remove them\.
+The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\. These resources are no longer supported, but there are no plans to remove them\.
 
 ## How do I install the Amazon EBS CSI driver?<a name="csi-migration-faq-ebs-csi-driver"></a>
 

--- a/doc_source/ebs-csi-migration-faq.md
+++ b/doc_source/ebs-csi-migration-faq.md
@@ -36,7 +36,7 @@ Yes, as long as the [Amazon EBS CSI driver](ebs-csi.md) is installed\.
 
 ## Will the `kubernetes.io/aws-ebs` `StorageClass` provisioner ever be removed from Amazon EKS?<a name="csi-migration-faq-aws-ebs-provisioner"></a>
 
-The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\. These resources are no longer supported, but there are no plans to remove them\.
+No\. The `StorageClass` provisioner `kubernetes.io/aws-ebs` and volume type `awsElasticBlockStore` are treated as a part of the Kubernetes API\. These resources are no longer supported and there are no plans to remove them\.
 
 ## How do I install the Amazon EBS CSI driver?<a name="csi-migration-faq-ebs-csi-driver"></a>
 


### PR DESCRIPTION
Update formatting as the words are being merged into one so they need a space. Also removes the `No` from one of the FAQ answers because later on in the answer we say that there are no plans. So it's best to just remove the `No` because it gives the impression that there it will never be removed, whereas the `No plans to remove them` doesn't remove that option completely, it just says there are no plans currently (which could change)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
