### PR TITLE
Update VPC CNI recommended version to v1.12.6-eksbuild.1

### DIFF
--- a/doc_source/managing-vpc-cni.md
+++ b/doc_source/managing-vpc-cni.md
@@ -7,9 +7,9 @@ A version of the add\-on is deployed with each Fargate node in your cluster, but
 The following table lists the latest available version of the Amazon EKS add\-on type for each Kubernetes version\.<a name="vpc-cni-latest-available-version"></a>
 
 
-| Kubernetes version | `1.25` | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | 
-| --- | --- | --- | --- | --- | --- | --- | 
-|  | v1\.12\.5\-eksbuild\.2 | v1\.12\.5\-eksbuild\.2 | v1\.12\.5\-eksbuild\.2 | v1\.12\.5\-eksbuild\.2 | v1\.12\.5\-eksbuild\.1 | v1\.12\.0\-eksbuild\.2 | 
+| Kubernetes version | `1.25` | `1.24` | `1.23` | `1.22` | `1.21` |
+| --- | --- | --- | --- | --- | --- | --- |
+|  | v1\.12\.6\-eksbuild\.1 | v1\.12\.6\-eksbuild\.1 | v1\.12\.6\-eksbuild\.1 | v1\.12\.6\-eksbuild\.1 | v1\.12\.6\-eksbuild\.1 |
 
 **Important**  
 If you're self\-managing this add\-on, the versions in the table might not be the same as the available self\-managed versions\. For more information about updating the self\-managed type of this add\-on, see [Updating the self\-managed add\-on](#vpc-add-on-self-managed-update)\.<a name="manage-vpc-cni-add-on-on-prerequisites"></a>


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
This PR updates the VPC CNI recommended version to v1.12.6-eksbuild.1. It also removes EKS 1.20 from the chart as we no longer support this version. We no longer support EKS 1.21 either, but I am leaving it for now as its end of life was recent.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
