### PR TITLE
EFS example output incorrect name compared to the naming given in the example files

### DIFF
--- a/doc_source/efs-csi.md
+++ b/doc_source/efs-csi.md
@@ -536,7 +536,7 @@ This procedure uses the [Dynamic Provisioning](https://github.com/kubernetes-sig
 
    ```
    NAME          READY   STATUS    RESTARTS   AGE   IP               NODE                                           NOMINATED NODE   READINESS GATES
-   efs-example   1/1     Running   0          10m   192.168.78.156   ip-192-168-73-191.region-code.compute.internal   <none>           <none>
+   efs-app   1/1     Running   0          10m   192.168.78.156   ip-192-168-73-191.region-code.compute.internal   <none>           <none>
    ```
 **Note**  
 If a pod doesn't have an IP address listed, make sure that you added a mount target for the subnet that your node is in \(as described at the end of [Create an Amazon EFS file system](#efs-create-filesystem)\)\. Otherwise the pod won't leave `ContainerCreating` status\. When an IP address is listed, it may take a few minutes for a pod to reach the `Running` status\.


### PR DESCRIPTION


*Issue #, if available:*
n/a but a little bit confusing due to example files provided using different naming convention

*Description of changes:*
As per https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/1f49c2f73b71614f5e0e157a0420f9378ce42615/examples/kubernetes/dynamic_provisioning/specs/pod.yaml#L17 the new name of the pod is efs-app

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
