### PR TITLE
Update kubecost for supporting k8s 1.25

### DIFF
--- a/doc_source/cost-monitoring.md
+++ b/doc_source/cost-monitoring.md
@@ -12,10 +12,10 @@ Amazon EKS provides an AWS optimized bundle of Kubecost for cluster cost visibil
 
 **To install Kubecost**
 
-1. Install Kubecost with the following command\. You can replace *1\.96\.0* with a later version\. You can see the available versions at [kubecost/cost\-analyzer](https://gallery.ecr.aws/kubecost/cost-analyzer) in the Amazon ECR Public Gallery\.
+1. Install Kubecost with the following command\. You can replace *1\.98\.0* with a later version\. You can see the available versions at [kubecost/cost\-analyzer](https://gallery.ecr.aws/kubecost/cost-analyzer) in the Amazon ECR Public Gallery\.
 
    ```
-   helm upgrade -i kubecost oci://public.ecr.aws/kubecost/cost-analyzer --version 1.96.0 \
+   helm upgrade -i kubecost oci://public.ecr.aws/kubecost/cost-analyzer --version 1.98.0 \
        --namespace kubecost --create-namespace \
        -f https://raw.githubusercontent.com/kubecost/cost-analyzer-helm-chart/develop/cost-analyzer/values-eks-cost-monitoring.yaml
    ```


### PR DESCRIPTION
*Issue #, if available:*

Kubecost version `1.96` is broken and Pod cannot pass ReadinessProbe health check when running on Kubernetes `1.25` due to it uses Beta API version (`autoscaling/v2beta`) with the following error in the cost analyzer log:

```
$ kubectl get pods -n kubecost
NAME                                           READY   STATUS    RESTARTS   AGE
kubecost-cost-analyzer-78f8c76f76-wqr2x        0/2     Running   0          33s
kubecost-kube-state-metrics-75df9fd84f-bkjx8   1/1     Running   0          169m
kubecost-prometheus-server-fd44c55d4-vstkd     1/1     Running   0          169m
```

```
E0323 15:30:56.113107       1 reflector.go:138] pkg/mod/k8s.io/client-go@v0.20.4/tools/cache/reflector.go:167: Failed to watch *v2beta1.HorizontalPodAutoscaler: failed to list *v2beta1.HorizontalPodAutoscaler: the server could not find the requested resource
```

But I don't have this issue when deploying kubecost `1.96` on my Kubernetes `1.21` cluster. After installing latest version kubecost (e.g. `public.ecr.aws/kubecost/cost-analyzer:1.101.2`), the issue will be resolved on Kubernetes `1.25` cluster as well.

With few hours re-try and research, it is the problem in kubecost implementation was using Beta API (`autoscaling/v2beta1`) result in it cannot be initialized. Kubernetes graduated the HorizontalPodAutoscaler `autoscaling/v2` stable API to general availability. The HorizontalPodAutoscaler `autoscaling/v2beta2` API is deprecated since Kubernetes 1.23 [1].

So I will propose the documented step for installing kubecost version should be updated (`>=1.98`):
- https://github.com/opencost/opencost/issues/1440

*Description of changes:*

Update the version to `1.98` that support Kubernetes `1.25`, I tested this version and it also can be supported on Kubernetes `1.21`.
- https://github.com/opencost/opencost/pull/1452


[1] https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html#kubernetes-1.23

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
