### PR TITLE
KMS key ID changed to ARN for the IAM Policy

### DIFF
--- a/doc_source/csi-iam-role.md
+++ b/doc_source/csi-iam-role.md
@@ -33,9 +33,9 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
      --role-name AmazonEKS_EBS_CSI_DriverRole
    ```
 
-1. If you use a custom KMS key for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
+1. If you use a custom [KMS key](https://aws.amazon.com/kms/) for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
 
-   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-arn` with the custom KMS key ARN\.
+   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-arn` with the custom [KMS key ARN](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awskeymanagementservice.html#awskeymanagementservice-key)\.
 
       ```
       {
@@ -141,7 +141,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
 
 1. Choose **Update policy** to finish\.
 
-1. If you use a custom KMS key for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
+1. If you use a custom [KMS key](https://aws.amazon.com/kms/) for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
 
    1. In the left navigation pane, choose **Policies**\.
 
@@ -149,7 +149,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
 
    1. On the **Create policy** page, choose the **JSON** tab\.
 
-   1. Copy and paste the following code into the editor, replacing `custom-key-id` with the custom KMS key ID:
+   1. Copy and paste the following code into the editor, replacing `custom-key-arn` with the custom [KMS key ARN](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awskeymanagementservice.html#awskeymanagementservice-key):
 
       ```
       {
@@ -162,7 +162,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:ListGrants",
               "kms:RevokeGrant"
             ],
-            "Resource": ["custom-key-id"],
+            "Resource": ["custom-key-arn"],
             "Condition": {
               "Bool": {
                 "kms:GrantIsForAWSResource": "true"
@@ -178,7 +178,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:GenerateDataKey*",
               "kms:DescribeKey"
             ],
-            "Resource": ["custom-key-id"]
+            "Resource": ["custom-key-arn"]
           }
         ]
       }
@@ -281,9 +281,9 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
      --role-name AmazonEKS_EBS_CSI_DriverRole
    ```
 
-1. If you use a custom KMS key for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
+1. If you use a custom [KMS key](https://aws.amazon.com/kms/) for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
 
-   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-id` with the custom KMS key ID\.
+   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-arn` with the custom [KMS key ARN](https://docs.aws.amazon.com/service-authorization/latest/reference/list_awskeymanagementservice.html#awskeymanagementservice-key)\.
 
       ```
       {
@@ -296,7 +296,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:ListGrants",
               "kms:RevokeGrant"
             ],
-            "Resource": ["custom-key-id"],
+            "Resource": ["custom-key-arn"],
             "Condition": {
               "Bool": {
                 "kms:GrantIsForAWSResource": "true"
@@ -312,7 +312,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:GenerateDataKey*",
               "kms:DescribeKey"
             ],
-            "Resource": ["custom-key-id"]
+            "Resource": ["custom-key-arn"]
           }
         ]
       }

--- a/doc_source/csi-iam-role.md
+++ b/doc_source/csi-iam-role.md
@@ -35,7 +35,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
 
 1. If you use a custom KMS key for encryption on your Amazon EBS volumes, customize the IAM role as needed\. For example, do the following:
 
-   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-id` with the custom KMS key ID\.
+   1. Copy and paste the following code into a new `kms-key-for-encryption-on-ebs.json` file\. Replace `custom-key-arn` with the custom KMS key ARN\.
 
       ```
       {
@@ -48,7 +48,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:ListGrants",
               "kms:RevokeGrant"
             ],
-            "Resource": ["custom-key-id"],
+            "Resource": ["custom-key-arn"],
             "Condition": {
               "Bool": {
                 "kms:GrantIsForAWSResource": "true"
@@ -64,7 +64,7 @@ Create an IAM role and attach the required AWS managed policy to it\. You can us
               "kms:GenerateDataKey*",
               "kms:DescribeKey"
             ],
-            "Resource": ["custom-key-id"]
+            "Resource": ["custom-key-arn"]
           }
         ]
       }


### PR DESCRIPTION
*Description of changes:*
IAM policy expects an ARN for the resource property. Key ID changed to Key ARN in the documentation.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
