### PR TITLE
Add information about cached container images on EKS Windows AMIs

### DIFF
--- a/doc_source/eks-optimized-windows-ami.md
+++ b/doc_source/eks-optimized-windows-ami.md
@@ -22,7 +22,7 @@ Amazon EKS offers AMIs that are optimized for Windows containers in the followin
 **Important**  
 The Amazon EKS\-optimized Windows Server 20H2 Core AMI is deprecated\. No new versions of this AMI will be released\.
 
-## Amazon EKS Windows AMI release calendar<a name="windows-ami--release-calendar"></a>
+## Release calendar<a name="windows-ami--release-calendar"></a>
 
 The following table lists the release and end of support dates for Windows versions on Amazon EKS\. If an end date is blank, it's because the version is still supported\.
 
@@ -161,7 +161,7 @@ Amazon EKS Windows pods allow different types of group Managed Service Account \
 + Amazon EKS supports Active Directory domain identities for authentication\. For more information on domain\-joined gMSA, see [Windows Authentication on Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/windows-authentication-on-amazon-eks-windows-pods/) on the AWS blog\.
 + Amazon EKS offers a plugin that enables non\-domain\-joined Windows nodes to retrieve gMSA credentials with a portable user identity\. For more information on domainless gMSA, see [Domainless Windows Authentication for Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/domainless-windows-authentication-for-amazon-eks-windows-pods/) on the AWS blog\.
 
-## Cached container images on Amazon EKS Windows optimized AMIs<a name="windows-cached-container-images"></a>
+## Cached container images<a name="windows-cached-container-images"></a>
 Amazon EKS Windows optimized AMIs have certain container images cached for both the `docker` and `containerd` runtimes. Container images are cached when building custom AMIs using Amazon-managed build components. For more information, see [Using the Amazon-managed build component](https://docs.aws.amazon.com/eks/latest/userguide/eks-custom-ami-windows.html#custom-windows-ami-build-component).
 
 #### For Amazon EKS `1.23` and lower

--- a/doc_source/eks-optimized-windows-ami.md
+++ b/doc_source/eks-optimized-windows-ami.md
@@ -161,22 +161,22 @@ Amazon EKS Windows pods allow different types of group Managed Service Account \
 + Amazon EKS supports Active Directory domain identities for authentication\. For more information on domain\-joined gMSA, see [Windows Authentication on Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/windows-authentication-on-amazon-eks-windows-pods/) on the AWS blog\.
 + Amazon EKS offers a plugin that enables non\-domain\-joined Windows nodes to retrieve gMSA credentials with a portable user identity\. For more information on domainless gMSA, see [Domainless Windows Authentication for Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/domainless-windows-authentication-for-amazon-eks-windows-pods/) on the AWS blog\.
 
-## Cached Container images on EKS Windows optimized AMIs
-EKS Windows Optimized AMIs have certain container images cached for both docker and containerd runtime. Container images will be cached when building custom AMI using Amazon-managed build component. For more information, see [Amazon-managed build component](https://docs.aws.amazon.com/eks/latest/userguide/eks-custom-ami-windows.html).
+## Cached container images on Amazon EKS Windows optimized AMIs<a name="windows-cached-container-images"></a>
+Amazon EKS Windows optimized AMIs have certain container images cached for both the `docker` and `containerd` runtimes. Container images are cached when building custom AMIs using Amazon-managed build components. For more information, see [Using the Amazon-managed build component](https://docs.aws.amazon.com/eks/latest/userguide/eks-custom-ami-windows.html#custom-windows-ami-build-component).
 
 #### For Amazon EKS `1.23` and lower
 
-docker is default runtime and have following container images cached on EKS Windows AMIs. Retrieve this image list by running `docker images` on EKS windows node.
+The `docker` runtime is the default and has the following container images cached on Amazon EKS Windows AMIs. Retrieve this image list by running `docker images` on the Amazon EKS Windows node:
 - `amazonaws.com/eks/pause-windows`
 - `mcr.microsoft.com/windows/nanoserver`
 - `mcr.microsoft.com/windows/servercore`
 
-containerd runtime only has one container image. Run `ctr -n k8s.io images list` to get image list.
+The `containerd` runtime only has one container image. Retrieve this image list by running `ctr -n k8s.io images list`:
 - `amazonaws.com/eks/pause-windows`
 
 #### For Amazon EKS 1.24 and higher
 
-There is no docker runtime and following cached container images are for containerd runtime.
+There is no `docker` runtime. The following cached container images are for the `containerd` runtime:
 - `amazonaws.com/eks/pause-windows`
 - `mcr.microsoft.com/windows/nanoserver`
 - `mcr.microsoft.com/windows/servercore`

--- a/doc_source/eks-optimized-windows-ami.md
+++ b/doc_source/eks-optimized-windows-ami.md
@@ -161,6 +161,26 @@ Amazon EKS Windows pods allow different types of group Managed Service Account \
 + Amazon EKS supports Active Directory domain identities for authentication\. For more information on domain\-joined gMSA, see [Windows Authentication on Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/windows-authentication-on-amazon-eks-windows-pods/) on the AWS blog\.
 + Amazon EKS offers a plugin that enables non\-domain\-joined Windows nodes to retrieve gMSA credentials with a portable user identity\. For more information on domainless gMSA, see [Domainless Windows Authentication for Amazon EKS Windows pods](http://aws.amazon.com/blogs/containers/domainless-windows-authentication-for-amazon-eks-windows-pods/) on the AWS blog\.
 
+## Cached Container images on EKS Windows optimized AMIs
+EKS Windows Optimized AMIs have certain container images cached for both docker and containerd runtime. Container images will be cached when building custom AMI using Amazon-managed build component. For more information, see [Amazon-managed build component](https://docs.aws.amazon.com/eks/latest/userguide/eks-custom-ami-windows.html).
+
+#### For Amazon EKS `1.23` and lower
+
+docker is default runtime and have following container images cached on EKS Windows AMIs. Retrieve this image list by running `docker images` on EKS windows node.
+- `amazonaws.com/eks/pause-windows`
+- `mcr.microsoft.com/windows/nanoserver`
+- `mcr.microsoft.com/windows/servercore`
+
+containerd runtime only has one container image. Run `ctr -n k8s.io images list` to get image list.
+- `amazonaws.com/eks/pause-windows`
+
+#### For Amazon EKS 1.24 and higher
+
+There is no docker runtime and following cached container images are for containerd runtime.
+- `amazonaws.com/eks/pause-windows`
+- `mcr.microsoft.com/windows/nanoserver`
+- `mcr.microsoft.com/windows/servercore`
+
 ## More information<a name="windows-more-information"></a>
 
 For more information about using Amazon EKS optimized Windows AMIs, see the following sections:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
1. Add section about cached images for all supported EKS versions.
2. Added information about both runtime i.e. docker and containerd.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
