### PR TITLE
Update aws-iam-authenticator version from 0.5.9 to 0.6.11

### DIFF
--- a/doc_source/install-aws-iam-authenticator.md
+++ b/doc_source/install-aws-iam-authenticator.md
@@ -39,11 +39,11 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Download the `aws-iam-authenticator` binary from GitHub for your hardware platform\. The first command downloads the `amd64` release\. The second command downloads the `arm64` release\.
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_darwin_amd64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_darwin_amd64
    ```
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_darwin_arm64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_darwin_arm64
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -51,17 +51,17 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/authenticator_0.5.9_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\. The first command returns the `amd64` checksum\. The second command returns the `arm64` checksum\.
 
       ```
-      awk '/aws-iam-authenticator_0.5.9_darwin_amd64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.2_darwin_amd64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       ```
-      awk '/aws-iam-authenticator_0.5.9_darwin_arm64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.2_darwin_arm64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       The example output is as follows\.
@@ -116,11 +116,11 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Download the `aws-iam-authenticator` binary from GitHub for your hardware platform\. The first command downloads the `amd64` release\. The second command downloads the `arm64` release\.
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_amd64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_linux_amd64
    ```
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_linux_arm64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_linux_arm64
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -128,17 +128,17 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/authenticator_0.5.9_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\. The first command returns the `amd64` checksum\. The second command returns the `arm64` checksum\.
 
       ```
-      awk '/aws-iam-authenticator_0.5.9_linux_amd64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.2_linux_amd64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       ```
-      awk '/aws-iam-authenticator_0.5.9_linux_arm64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.2_linux_arm64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       The example output is as follows\.
@@ -209,7 +209,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Open a PowerShell terminal window and download the `aws-iam-authenticator` binary from GitHub\.
 
    ```
-   curl -Lo aws-iam-authenticator.exe https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/aws-iam-authenticator_0.5.9_windows_amd64.exe
+   curl -Lo aws-iam-authenticator.exe https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_windows_amd64.exe
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -217,7 +217,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.5.9/authenticator_0.5.9_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\.
@@ -230,7 +230,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
       The example output is as follows\.
 
       ```
-      b7345e06c5f1d31b9459a38baffe0744343711cb5042cb31ff1e072d870c42f9  aws-iam-authenticator_0.5.9_windows_amd64.exe
+      b7345e06c5f1d31b9459a38baffe0744343711cb5042cb31ff1e072d870c42f9  aws-iam-authenticator_0.6.2_windows_amd64.exe
       ```
 
    1. Determine the `SHA-256` checksum for your downloaded binary\.

--- a/doc_source/install-aws-iam-authenticator.md
+++ b/doc_source/install-aws-iam-authenticator.md
@@ -39,11 +39,11 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Download the `aws-iam-authenticator` binary from GitHub for your hardware platform\. The first command downloads the `amd64` release\. The second command downloads the `arm64` release\.
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_darwin_amd64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_darwin_amd64
    ```
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_darwin_arm64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_darwin_arm64
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -51,17 +51,17 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/authenticator_0.6.11_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\. The first command returns the `amd64` checksum\. The second command returns the `arm64` checksum\.
 
       ```
-      awk '/aws-iam-authenticator_0.6.2_darwin_amd64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.11_darwin_amd64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       ```
-      awk '/aws-iam-authenticator_0.6.2_darwin_arm64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.11_darwin_arm64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       The example output is as follows\.
@@ -116,11 +116,11 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Download the `aws-iam-authenticator` binary from GitHub for your hardware platform\. The first command downloads the `amd64` release\. The second command downloads the `arm64` release\.
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_linux_amd64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_linux_amd64
    ```
 
    ```
-   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_linux_arm64
+   curl -Lo aws-iam-authenticator https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_linux_arm64
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -128,17 +128,17 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/authenticator_0.6.11_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\. The first command returns the `amd64` checksum\. The second command returns the `arm64` checksum\.
 
       ```
-      awk '/aws-iam-authenticator_0.6.2_linux_amd64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.11_linux_amd64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       ```
-      awk '/aws-iam-authenticator_0.6.2_linux_arm64/ {print $1}' aws-iam-authenticator.txt
+      awk '/aws-iam-authenticator_0.6.11_linux_arm64/ {print $1}' aws-iam-authenticator.txt
       ```
 
       The example output is as follows\.
@@ -209,7 +209,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
 1. Open a PowerShell terminal window and download the `aws-iam-authenticator` binary from GitHub\.
 
    ```
-   curl -Lo aws-iam-authenticator.exe https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/aws-iam-authenticator_0.6.2_windows_amd64.exe
+   curl -Lo aws-iam-authenticator.exe https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/aws-iam-authenticator_0.6.11_windows_amd64.exe
    ```
 
 1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for the file\. 
@@ -217,7 +217,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
    1. Download the `SHA-256` checksum file\.
 
       ```
-      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.2/authenticator_0.6.2_checksums.txt
+      curl -Lo aws-iam-authenticator.txt https://github.com/kubernetes-sigs/aws-iam-authenticator/releases/download/v0.6.11/authenticator_0.6.11_checksums.txt
       ```
 
    1. View the checksum for the authenticator binary that you downloaded\.
@@ -230,7 +230,7 @@ You can also install the `aws-iam-authenticator` by following these steps\.
       The example output is as follows\.
 
       ```
-      b7345e06c5f1d31b9459a38baffe0744343711cb5042cb31ff1e072d870c42f9  aws-iam-authenticator_0.6.2_windows_amd64.exe
+      b7345e06c5f1d31b9459a38baffe0744343711cb5042cb31ff1e072d870c42f9  aws-iam-authenticator_0.6.11_windows_amd64.exe
       ```
 
    1. Determine the `SHA-256` checksum for your downloaded binary\.


### PR DESCRIPTION
*Description of changes:*
Latest release of aws-iam-authenticator tool is 0.6.11, see link below https://github.com/kubernetes-sigs/aws-iam-authenticator/releases

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.