### PR TITLE
Added date for Kubernetes v1.23 EOS

### DIFF
--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -178,7 +178,7 @@ Dates with only a month and a year are approximate and are updated with an exact
 | 1\.26 | December 9, 2022 | April 11, 2023 | June 2024 | 
 | 1\.25 | August 23, 2022 | February 22, 2023 | May 2024 | 
 | 1\.24 | May 3, 2022 | November 15, 2022 | January 2024 | 
-| 1\.23 | December 7, 2021 | August 11, 2022 | October 2023 | 
+| 1\.23 | December 7, 2021 | August 11, 2022 | October 11, 2023 | 
 | 1\.22 | August 4, 2021 | April 4, 2022 | June 4, 2023 | 
 | 1\.21 | April 8, 2021 | July 19, 2021 | February 15, 2023 | 
 | 1\.20 | December 8, 2020 | May 18, 2021 | November 1, 2022 | 


### PR DESCRIPTION
Adding end of support date for Kubernetes v1.23

*Issue #, if available:*

*Description of changes:*
Added end of support date for Kubernetes v1.23 on EKS. Earlier it was just month and year, now added an accurate date

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
