### PR TITLE
Update managing-kube-proxy.md

### DIFF
--- a/doc_source/managing-kube-proxy.md
+++ b/doc_source/managing-kube-proxy.md
@@ -10,12 +10,15 @@ There are two types of the `kube-proxy` container image available for each Amazo
 + **Minimal** – This image type is based on a [minimal base image](https://gallery.ecr.aws/eks-distro-build-tooling/eks-distro-minimal-base-iptables) maintained by Amazon EKS Distro, which contains minimal packages and doesn't have shells\. For more information, see [Amazon EKS Distro](https://distro.eks.amazonaws.com/)\.<a name="kube-proxy-latest-versions-table"></a><a name="kube-proxy-latest-tags"></a>
 
 
+
 **Latest available self\-managed `kube-proxy` container image version for each Amazon EKS cluster version**  
 
 | Image type | `1.26` | `1.25` | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | 
 | --- | --- | --- | --- | --- | --- | --- | --- | 
 | kube\-proxy \(default type\) | v1\.26\.2\-eksbuild\.1 | v1\.25\.6\-eksbuild\.2 | v1\.24\.10\-eksbuild\.2 | v1\.23\.16\-eksbuild\.2 | v1\.22\.17\-eksbuild\.2 | v1\.21\.14\-eksbuild\.2 | v1\.20\.15\-eksbuild\.2 | 
 | kube\-proxy \(minimal type\) | v1\.26\.2\-minimal\-eksbuild\.1 | v1\.25\.6\-minimal\-eksbuild\.2 | v1\.24\.10\-minimal\-eksbuild\.1 | v1\.23\.16\-minimal\-eksbuild\.2 | v1\.22\.17\-minimal\-eksbuild\.2 | v1\.21\.14\-minimal\-eksbuild\.4 | v1\.20\.15\-minimal\-eksbuild\.4 | 
+
+The kube-proxy images since 1.25 version are only shipped as minimal type. The default type image is symlinked to minimal type. 
 
 **Important**  
 When you [update an Amazon EKS add\-on type](managing-add-ons.md#updating-an-add-on), you specify a valid Amazon EKS add\-on version, which might not be a version listed in this table\. This is because [Amazon EKS add\-on](eks-add-ons.md#add-ons-kube-proxy) versions don't always match container image versions specified when updating the self\-managed type of this add\-on\. When you update the self\-managed type of this add\-on, you specify a valid container image version listed in this table\. 


### PR DESCRIPTION
Only minimal type images are shipped with EKS 1.25 on wards.

*Issue #, if available:*

Address an internal issue raised wherein they noticed "default type" of EKS 1.25 had  different iptables version than "default type" of kube-proxy in EKS 1.24.

This explanation will clarify the difference.

*Description of changes:*

* Only minimal type images are shipped with EKS 1.25 on wards.
