### PR TITLE
Update command to view the details of any rolebinding or clusterrolebinding

### DIFF
--- a/doc_source/add-user-role.md
+++ b/doc_source/add-user-role.md
@@ -104,7 +104,7 @@ For more information about Kubernetes role\-based access control \(RBAC\) config
       Replace `role-binding-name` with a `rolebinding` name returned in the output from the previous command\. Replace `kube-system` with the `namespace` of the `rolebinding`\.
 
       ```
-      kubectl describe rolebinding role-binding-name -n kube-system
+      kubectl get rolebinding role-binding-name -n kube-system -oyaml
       ```
 
       The example output is as follows\.
@@ -128,7 +128,7 @@ For more information about Kubernetes role\-based access control \(RBAC\) config
       Replace `cluster-role-binding-name` with a `clusterrolebinding` name returned in the output from the previous command\.
 
       ```
-      kubectl describe clusterrolebinding cluster-role-binding-name
+      kubectl get clusterrolebinding cluster-role-binding-name -oyaml
       ```
 
       The example output is as follows\.


### PR DESCRIPTION
Update command to view the details of any rolebinding or clusterrolebinding which should be a `get` instead of a `describe` because the output shows that it is a `get`.

*Issue #, if available: n/a

*Description of changes: The displayed output when running the command to view the details of any rolebinding/clusterrolebinding is for a `kubectl get` not a `kubectl describe` command. Updating the command to `kubectl get` to align with the output.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
