### PR TITLE
update coredns

### DIFF
--- a/doc_source/managing-coredns.md
+++ b/doc_source/managing-coredns.md
@@ -7,7 +7,7 @@ The following table lists the latest version of the Amazon EKS add\-on type for 
 
 | Kubernetes version | `1.27` | `1.26` | `1.25` | `1.24` | `1.23` | `1.22` | `1.21` | `1.20` | 
 | --- | --- | --- | --- | --- | --- | --- | --- | --- | 
-|  | v1\.10\.1\-eksbuild\.1 | v1\.9\.3\-eksbuild\.3 | v1\.9\.3\-eksbuild\.3 | v1\.9\.3\-eksbuild\.3 | v1\.8\.7\-eksbuild\.4 | v1\.8\.7\-eksbuild\.4 | v1\.8\.4\-eksbuild\.2 | v1\.8\.3\-eksbuild\.1 | 
+|  | v1\.10\.1\-eksbuild\.1 | v1\.9\.3\-eksbuild\.3 | v1\.9\.3\-eksbuild\.3 | v1\.9\.3\-eksbuild\.3 | v1\.8\.7\-eksbuild\.5 | v1\.8\.7\-eksbuild\.5 | v1\.8\.4\-eksbuild\.2 | v1\.8\.3\-eksbuild\.1 | 
 
 **Important**  
 If you're self\-managing this add\-on, the versions in the table might not be the same as the available self\-managed versions\. For more information about updating the self\-managed type of this add\-on, see [Updating the self\-managed add\-on](#coredns-add-on-self-managed-update)\.


### PR DESCRIPTION
We published a new version of CoreDNS 1.8.7-eksbuild.5. Once deployment to all regions is complete, the docs need to be updated to reflect the new version availability. 

