### PR TITLE
Fix command to edit aws-node for CNI network policy doc

### DIFF
--- a/doc_source/cni-network-policy.md
+++ b/doc_source/cni-network-policy.md
@@ -142,7 +142,7 @@ For all other cluster versions, if you upgrade the Amazon EKS optimized Amazon L
         1. Open the `aws-node` `DaemonSet` in your editor\.
 
            ```
-           kubectl edit daemonset -n kube-system amazon-vpc-cni -o yaml
+           kubectl edit daemonset -n kube-system aws-node
            ```
 
         1. Replace the `false` with `true` in the command argument `--enable-network-policy=false` in the `args:` in the `aws-network-policy-agent` container in the VPC CNI `aws-node` daemonset manifest\.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The command to edit the `aws-node` daemonset was wrong, so I updated it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
