### PR TITLE
Update pod-id-role.md - fix action taken in doc

### DIFF
--- a/doc_source/pod-id-role.md
+++ b/doc_source/pod-id-role.md
@@ -20,7 +20,7 @@
 ```
 
 `sts:AssumeRole`  
-EKS Pod Identity uses `TagSession` to assume the IAM role before passing the temporary credentials to your pods\.
+EKS Pod Identity uses `AssumeRole` to assume the IAM role before passing the temporary credentials to your pods\.
 
 `sts:TagSession`  
 EKS Pod Identity uses `TagSession` to include *session tags* in the requests to AWS STS\.  


### PR DESCRIPTION
Fix action taken - EKS Pod Identity uses `AssumeRole` to assume the IAM role, not 'TagSession'.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
