### PR TITLE
Update kubernetes-versions.md

### DIFF
--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -15,13 +15,13 @@ The following Kubernetes versions are currently available in Amazon EKS standard
 + `1.29`
 + `1.28`
 + `1.27`
-+ `1.26`
 
 For important changes to be aware of for each version in standard support, see [Release notes for standard support versions](kubernetes-versions-standard.md)\.
 
 ## Available versions on extended support<a name="available-versions-extended"></a>
 
 The following Kubernetes versions are currently available in Amazon EKS extended support:
++ `1.26`
 + `1.25`
 + `1.24`
 + `1.23`


### PR DESCRIPTION
Updating to reflect that 1.26 ended standard support two days ago on June 11, 2024

*Issue #, if available: N/A

*Description of changes: Moved 1.26 from supported to extended support


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
