### PR TITLE
Correct configuration values for updating CoreDNS auto-scaling via CLI

### DIFF
--- a/doc_source/coredns-autoscaling.md
+++ b/doc_source/coredns-autoscaling.md
@@ -209,7 +209,7 @@ Every platform version of later Kubernetes versions are also supported, for exam
 
    ```
    aws eks update-addon --cluster-name my-cluster --addon-name coredns \
-       --resolve-conflicts PRESERVE --configuration-values '{"autoScaling":{"enabled":true}, "minReplicas": 2, "maxReplicas": 10}'
+       --resolve-conflicts PRESERVE --configuration-values '{"autoScaling":{"enabled":true,"minReplicas":2,"maxReplicas":10}}'
    ```
 
 1. Check the status of the update to the add\-on by running the following command:


### PR DESCRIPTION
*Description of changes:*

`minReplicas` and `maxReplicas` need to go inside the `autoScaling` block.

Current documented command returns:

```
An error occurred (InvalidParameterException) when calling the UpdateAddon operation: ConfigurationValue provided in request is not supported: Json schema validation failed with error: [$.minReplicas: is not defined in the schema and the schema does not allow additional properties, $.maxReplicas: is not defined in the schema and the schema does not allow additional properties]
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
