### PR TITLE
Update s3-csi.md - Prerequisite

### DIFF
--- a/doc_source/s3-csi.md
+++ b/doc_source/s3-csi.md
@@ -12,6 +12,7 @@ Static provisioning refers to using an existing Amazon S3 bucket that is specifi
 
 **Prerequisites**
 + An existing AWS Identity and Access Management \(IAM\) OpenID Connect \(OIDC\) provider for your cluster\. To determine whether you already have one, or to create one, see [Create an IAM OIDC provider for your cluster](enable-iam-roles-for-service-accounts.md)\.
++ An existing EFS CSI Driver is also required as storage won't be provisioned without that. Check [Related Issue.](https://github.com/awslabs/mountpoint-s3-csi-driver/issues/185#issuecomment-2097980816)
 + Version 2\.12\.3 or later of the AWS CLI installed and configured on your device or AWS CloudShell\.
 + The `kubectl` command line tool is installed on your device or AWS CloudShell\. The version can be the same as or up to one minor version earlier or later than the Kubernetes version of your cluster\. For example, if your cluster version is `1.29`, you can use `kubectl` version `1.28`, `1.29`, or `1.30` with it\. To install or upgrade `kubectl`, see [Installing or updating `kubectl`](install-kubectl.md)\.
 


### PR DESCRIPTION
Updated one more prerequiste which I tested on my own as well.

*Issue #, if available:*
Without EFS CSI Driver installed, S3 CSI Driver won't work and will throw below error:
```
0/2 nodes are available: pod has unbound immediate PersistentVolumeClaims. preemption: 0/2 nodes are available: 2 Preemption is not helpful for scheduling..
```

*Description of changes:*
Addition of a point i.e., "While using S3 CSI Driver, we require EFS CSI Driver as storage won't be provisioned to get PersistentVolume mounted." I have tested this as well today and it's working.

Checkout related Issue: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/185#issuecomment-2097980816

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
