### PR TITLE
Update quickstart.md to include missing namespace to ebs-pvc.yaml

### DIFF
--- a/doc_source/quickstart.md
+++ b/doc_source/quickstart.md
@@ -206,6 +206,7 @@ Now that the 2048 game is up and running on your Amazon EKS cluster, it's time t
    apiVersion: v1
    kind: PersistentVolumeClaim
    metadata:
+     namespace: game-2048
      name: game-data-pvc
    spec:
      accessModes:


### PR DESCRIPTION
### Summary

This pull request fixes an issue where the ebs-pvc.yaml file was missing the namespace field. This caused the PVC to be created in the default namespace instead of the intended `game-2048` namespace. This prevented the PVC from binding with the ebs-sc Storage class. This correction ensures that the PVC is created in the correct namespace and can bind to the Storage class properly.

### Changes

- Added the `namespace: game-2048` field to the `ebs-pvc.yaml` file to ensure the PVC is created in the correct namespace.

### File Modified

- `ebs-pvc.yaml`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
