### PR TITLE
Removed duplicated entries of 1.30 for linux

### DIFF
--- a/doc_source/install-kubectl.md
+++ b/doc_source/install-kubectl.md
@@ -179,11 +179,6 @@ You must use a `kubectl` version that is within one minor version difference of 
         ```
         curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/amd64/kubectl
         ```
-      + Kubernetes `1.30`
-
-        ```
-        curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/amd64/kubectl
-        ```
       + Kubernetes `1.29`
 
         ```
@@ -233,11 +228,6 @@ You must use a `kubectl` version that is within one minor version difference of 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for your binary\.
 
       1. Download the `SHA-256` checksum for your cluster's Kubernetes version from Amazon S3 using the command for your device's hardware platform\. The first link for each version is for `amd64` and the second link is for `arm64`\.
-         + Kubernetes `1.30`
-
-           ```
-           curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/amd64/kubectl.sha256
-           ```
          + Kubernetes `1.30`
 
            ```
@@ -340,11 +330,6 @@ This step assumes you are using the Bash shell; if you are using another shell, 
         ```
         curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/arm64/kubectl
         ```
-      + Kubernetes `1.30`
-
-        ```
-        curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/arm64/kubectl
-        ```
       + Kubernetes `1.29`
 
         ```
@@ -394,11 +379,6 @@ This step assumes you are using the Bash shell; if you are using another shell, 
    1. \(Optional\) Verify the downloaded binary with the `SHA-256` checksum for your binary\.
 
       1. Download the `SHA-256` checksum for your cluster's Kubernetes version from Amazon S3 using the command for your device's hardware platform\. The first link for each version is for `amd64` and the second link is for `arm64`\.
-         + Kubernetes `1.30`
-
-           ```
-           curl -O https://s3.us-west-2.amazonaws.com/amazon-eks/1.30.0/2024-05-12/bin/linux/arm64/kubectl.sha256
-           ```
          + Kubernetes `1.30`
 
            ```


### PR DESCRIPTION
*Description of changes:*
Download link for Kubernetes 1.30 is duplicated both for `Linux (amd64)` and `Linux (arm64)`. This PR removes duplication.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
