### PR TITLE
Update creating-a-vpc.md

### DIFF
--- a/doc_source/creating-a-vpc.md
+++ b/doc_source/creating-a-vpc.md
@@ -58,18 +58,6 @@ You can also assign `IPv6` addresses to nodes in public and private subnets\. Th
 
 1. Record the **SubnetIds** for the subnets that were created and whether you created them as public or private subnets\. You need at least two of these when you create your cluster and nodes\.
 
-1. If you created an `IPv4` VPC, skip this step\. If you created an `IPv6` VPC, you must enable the auto\-assign `IPv6` address option for the public subnets that were created by the template\. That setting is already enabled for the private subnets\. To enable the setting, complete the following steps:
-
-   1. Open the Amazon VPC console at [https://console\.aws\.amazon\.com/vpc/](https://console.aws.amazon.com/vpc/)\.
-
-   1. In the left navigation pane, choose **Subnets**
-
-   1. Select one of your public subnets \(***stack\-name*/SubnetPublic01** or ***stack\-name*/SubnetPublic02** contains the word **public**\) and choose **Actions**, **Edit subnet settings**\.
-
-   1. Choose the **Enable auto\-assign `IPv6` address** check box and then choose **Save**\.
-
-   1. Complete the previous steps again for your other public subnet\.
-
 ------
 #### [ Only public subnets ]
 


### PR DESCRIPTION
Removed 12th point from 'Public and Private subnets' section since 'AssignIpv6AddressOnCreation' is supported in public subnets in CFN.

*Issue #, if available:*
In the CFN template provided for VPC with public and private subnets (IPv4 and IPv6), e.g. https://s3.us-west-2.amazonaws.com/amazon-eks/cloudformation/2020-10-29/amazon-eks-ipv6-vpc-public-private-subnets.yaml a limitation has been mentioned -
```"Note: AssignIpv6AddressOnCreation: true is required but a CFN limitation right now, need to add this manually"``` 
Due to which we need to manually enable the auto-assign IPv6 address option for the public subnets that were created by the template (as per point 12)
Since this limitation has already been addressed by CFN, so 'AssignIpv6AddressOnCreation' property is supported in public subnets as well and hence manually performing this step is not required now

*Description of changes:*
- Please update the CFN template to include ```'AssignIpv6AddressOnCreation: true'``` in public subnets as well {See attachment for updated template [EKS-IPv4-IPv6.txt](https://github.com/user-attachments/files/16344183/EKS-IPv4-IPv6.txt) }
- Remove point 12 that describes how to manually enable the auto-assign IPv6 address option for the public subnets

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
