### PR TITLE
Fix typo in authenticate-oidc-identity-provider.md

### DIFF
--- a/doc_source/authenticate-oidc-identity-provider.md
+++ b/doc_source/authenticate-oidc-identity-provider.md
@@ -84,7 +84,7 @@ Don't specify `system:`, or any portion of that string, for `groupsPrefix` or `u
    + \(Optional\) Select **Advanced options**, enter or select the following information\.
      + **Username prefix** – Enter a prefix to prepend to username claims\. The prefix is prepended to username claims to prevent clashes with existing names\. If you do not provide a value, and the username is a value other than `email`, the prefix defaults to the value for **Issuer URL**\. You can use the value` -` to disable all prefixing\. Don't specify `system:` or any portion of that string\.
      + **Groups prefix** – Enter a prefix to prepend to groups claims\. The prefix is prepended to group claims to prevent clashes with existing names \(such as` system: groups`\)\. For example, the value `oidc:` creates group names like `oidc:engineering` and `oidc:infra`\. Don't specify `system:` or any portion of that string\.\.
-     + **Required claims** – Select **Add claim** and enter one or more key value pairs that describe required claims in the client ID token\. The paris describe required claims in the ID Token\. If set, each claim is verified to be present in the ID token with a matching value\.
+     + **Required claims** – Select **Add claim** and enter one or more key value pairs that describe required claims in the client ID token\. The pairs describe required claims in the ID Token\. If set, each claim is verified to be present in the ID token with a matching value\.
 
 1. To use `kubectl` to work with your cluster and OIDC identity provider, see [Using `kubectl`](https://kubernetes.io/docs/reference/access-authn-authz/authentication/#using-kubectl) in the Kubernetes documentation\.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixed a typo in the documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
