### PR TITLE
Update disable-extended-support.md - missing quotation marks in command

### DIFF
--- a/doc_source/disable-extended-support.md
+++ b/doc_source/disable-extended-support.md
@@ -27,5 +27,5 @@ AWS recommends upgrading your cluster to a version in the standard support perio
    ```
    aws eks update-cluster-config \
    --name <cluster-name> \
-   --upgrade-policy supportType = STANDARD
+   --upgrade-policy "supportType = STANDARD"
    ```


### PR DESCRIPTION
*Issue #, if available:*
they greyed out command in **Disable EKS extended support (AWS CLI)** is not recognized without quotation marks around supportType = STANDARD

*Description of changes:*
add quotation marks around "supportType = STANDARD"

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
