### PR TITLE
ebs-deployment.yaml refers to a pvc that doesn't exist

### DIFF
--- a/doc_source/quickstart.md
+++ b/doc_source/quickstart.md
@@ -207,6 +207,7 @@ Now that the 2048 game is up and running on your Amazon EKS cluster, it's time t
    kind: PersistentVolumeClaim
    metadata:
      name: game-data-pvc
+     namespace: game-2048
    spec:
      accessModes:
        - ReadWriteOnce


### PR DESCRIPTION
*Issue #, if available:* none

*Description of changes:* I noticed that the deployment wasn't starting up because K8S couldn't find the PVC. Maybe more importantly, after getting this working, there doesn't appear to be any stateful data saved. Are you sure the tutorial is referring to the correct image?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
