### PR TITLE
Removed v1.23 from currently available in extended support

### DIFF
--- a/doc_source/kubernetes-versions.md
+++ b/doc_source/kubernetes-versions.md
@@ -27,7 +27,6 @@ The following Kubernetes versions are currently available in Amazon EKS extended
 + `1.26`
 + `1.25`
 + `1.24`
-+ `1.23`
 
 For important changes to be aware of for each version in extended support, see [Review release notes for Kubernetes versions on extended support](kubernetes-versions-extended.md)\.
 


### PR DESCRIPTION
EKS v1.23 reached end of extended support on Oct 11th, 2024, but AWS EKS Documentation still shows EKS v1.23 under available versions in Extended support. So removed it to avoid confusion.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
