### PR TITLE
Nambinayagan patch 1

### DIFF
--- a/doc_source/disable-extended-support.md
+++ b/doc_source/disable-extended-support.md
@@ -27,5 +27,5 @@ AWS recommends upgrading your cluster to a version in the standard support perio
    ```
    aws eks update-cluster-config \
    --name <cluster-name> \
-   --upgrade-policy supportType = STANDARD
+   --upgrade-policy supportType=STANDARD
    ```

--- a/doc_source/enable-extended-support.md
+++ b/doc_source/enable-extended-support.md
@@ -31,5 +31,5 @@ If you do not enable extended support, your cluster will be automatically upgrad
    ```
    aws eks update-cluster-config \
    --name <cluster-name> \
-   --upgrade-policy supportType = EXTENDED
+   --upgrade-policy supportType=EXTENDED
    ```


### PR DESCRIPTION
*Issue #, if available:* Using the `aws eks update-cluster-config` command provided in disable-extended-support and enable-extended-support documentation caused below error:

>> Unknown options: STANDARD, =


*Description of changes:* The error was because the command to enable/disable Extended support had `supportType = string` where the additional spaces before and after "=" was causing issue. So changed it to `supportType=string` which follows the correct shorthand Syntax. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
