### PR TITLE
Update IAM role policy configuration to use `StringEquals` for Mountpoint for Amazon S3 CSI driver

### DIFF
--- a/latest/ug/storage/s3-csi.adoc
+++ b/latest/ug/storage/s3-csi.adoc
@@ -185,9 +185,9 @@ Add a comma to the end of the previous line, and then add the following line aft
 +
 [source,json,subs="verbatim,attributes,quotes"]
 ----
-"oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:s3-csi-*"
+"oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:s3-csi-driver-sa"
 ----
-. Change the `Condition` operator from `"StringEquals"` to `"StringLike"`.
+. Ensure that the `Condition` operator is set to `"StringEquals"`.
 . Choose *Update policy* to finish.
 
 === {aws} CLI [[awscli_s3_store_app_data]]
@@ -220,8 +220,8 @@ https://oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE
       },
       "Action": "sts:AssumeRoleWithWebIdentity",
       "Condition": {
-        "StringLike": {
-          "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:s3-csi-*",
+        "StringEquals": {
+          "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:kube-system:s3-csi-driver-sa",
           "oidc.eks.region-code.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:aud": "sts.amazonaws.com"
         }
       }


### PR DESCRIPTION
Currently, the documentation recommends that customers use a wildcard match `StringLike`  in their IAM role policy configuration for the CSI Driver EKS add-on. This approach is not considered a security best practice and has caused confusions for some customers (see: https://github.com/awslabs/mountpoint-s3-csi-driver/issues/300 and https://github.com/awslabs/mountpoint-s3-csi-driver/issues/173#issuecomment-2213021838).

In this pull request, we update the documentation to advice using `StringEquals` instead of `StringLike` to improve security and address these concerns.

/cc @unexge @muddyfish @dannycjones 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
