### PR TITLE
Added guidance for retrieving `CLUSTER_CA`, `APISERVER_ENDPOINT`, and `CLUSTER_ID` in BootstrapArguments section in outposts/eks-outposts-self-mana…

### DIFF
--- a/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
+++ b/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
@@ -115,6 +115,17 @@ NOTE: If you don't provide a key pair here, the {aws} CloudFormation stack creat
 ----
 --b64-cluster-ca ${CLUSTER_CA} --apiserver-endpoint https://${APISERVER_ENDPOINT} --enable-local-outpost true --cluster-id ${CLUSTER_ID}
 ----
+To retrieve the values for `CLUSTER_CA`, `APISERVER_ENDPOINT`, and `CLUSTER_ID` of your Amazon EKS local cluster, run the following AWS CLI commands. Replace cluster-name with the name of your cluster and region (for example, us-east-1) with your cluster’s AWS Region.
++
+[source,bash,subs="verbatim,attributes"]
+----
+echo "CLUSTER_CA=$(aws eks describe-cluster --name cluster-name --region region --query cluster.certificateAuthority.data --output text)"
+
+echo "APISERVER_ENDPOINT=$(aws eks describe-cluster --name cluster-name --region region --query cluster.endpoint --output text)"
+
+echo "CLUSTER_ID=$(aws eks describe-cluster --name cluster-name --region region --query cluster.id --output text)"
+----
+
 ** *DisableIMDSv1*: By default, each node supports the Instance Metadata Service Version 1 (IMDSv1) and IMDSv2. You can disable IMDSv1. To prevent future nodes and [.noloc]`Pods` in the node group from using IMDSv1, set  *DisableIMDSv1* to  *true*. For more information about IMDS, see link:AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Configuring the instance metadata service,type="documentation"]. For more information about restricting access to it on your nodes, see https://aws.github.io/aws-eks-best-practices/security/docs/iam/#restrict-access-to-the-instance-profile-assigned-to-the-worker-node[Restrict access to the instance profile assigned to the worker node].
 ** *VpcId*: Enter the ID for the  <<creating-a-vpc,VPC>> that you created. Before choosing a VPC, review <<outposts-vpc-requirements,VPC requirements and considerations>>.
 ** *Subnets*: If your cluster is on an Outpost, then choose at least one private subnet in your VPC. Before choosing subnets, review  <<outposts-subnet-requirements,Subnet requirements and considerations>>. You can see which subnets are private by opening each subnet link from the *Networking* tab of your cluster.


### PR DESCRIPTION
*Issue #, if available:*
[Missing information on CLUSTER_ID in EKS Documentation for outposts/eks-outposts-self-managed-nodes.adoc #833](https://github.com/awsdocs/amazon-eks-user-guide/issues/833)


*Description of changes:*
This PR addresses the issue of missing guidance in the BootstrapArguments section of the EKS user guide for AWS Outposts. It updates the documentation to include commands for retrieving the following values:
- `CLUSTER_CA`
- `APISERVER_ENDPOINT`
- `CLUSTER_ID`

These commands clarify how users can fetch these required values using the AWS CLI, making the instructions for self-managed nodes on AWS Outposts using AWS Management Console more complete and user-friendly.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.