### PR TITLE
Update launch-node-ubuntu.adoc

### DIFF
--- a/latest/ug/nodes/launch-node-ubuntu.adoc
+++ b/latest/ug/nodes/launch-node-ubuntu.adoc
@@ -64,7 +64,6 @@ nodeGroups:
     instanceType: m5.large
     desiredCapacity: 3
     amiFamily: Ubuntu2204
-    ami: auto-ssm
     iam:
        attachPolicyARNs:
           - {arn-aws}iam::aws:policy/AmazonEKSWorkerNodePolicy


### PR DESCRIPTION
Removing `ami: auto-ssm` as it makes "think" eksctl that it is a custom ami, throwing an error (needing `overrideBootstrapCommand`)

``` 
Error: nodeGroups[0].overrideBootstrapCommand is required when using a custom AMI based on Ubuntu2204 (nodeGroups[0].ami) 
```

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
