### PR TITLE
Update efs-csi.adoc

### DIFF
--- a/latest/ug/storage/efs-csi.adoc
+++ b/latest/ug/storage/efs-csi.adoc
@@ -179,19 +179,19 @@ aws iam attach-role-policy \
 [[efs-install-driver,efs-install-driver.title]]
 == Step 2: Get the Amazon EFS CSI driver
 
-We recommend that you install the Amazon EFS CSI driver through the Amazon EKS add-on. To add an Amazon EKS add-on to your cluster, see <<creating-an-add-on>>. For more information about add-ons, see <<eks-add-ons>>. If you're unable to use the Amazon EKS add-on, we encourage you to submit an issue about why you can't to the https://github.com/aws/containers-roadmap/issues[Containers roadmap GitHub repository].
-
-Alternatively, if you want a self-managed installation of the Amazon EFS CSI driver, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#installation[Installation] on [.noloc]`GitHub`.
-
-[[efs-create-filesystem,efs-create-filesystem.title]]
-== Step 3: Create an Amazon EFS file system
-
 [NOTE]
 ====
 
 This step isn't needed for {aws} Fargate. A [.noloc]`Pod` running on Fargate automatically mounts an Amazon EFS file system, without needing manual driver installation steps.
 
 ====
+
+We recommend that you install the Amazon EFS CSI driver through the Amazon EKS add-on. To add an Amazon EKS add-on to your cluster, see <<creating-an-add-on>>. For more information about add-ons, see <<eks-add-ons>>. If you're unable to use the Amazon EKS add-on, we encourage you to submit an issue about why you can't to the https://github.com/aws/containers-roadmap/issues[Containers roadmap GitHub repository].
+
+Alternatively, if you want a self-managed installation of the Amazon EFS CSI driver, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#installation[Installation] on [.noloc]`GitHub`.
+
+[[efs-create-filesystem,efs-create-filesystem.title]]
+== Step 3: Create an Amazon EFS file system
 
 To create an Amazon EFS file system, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/efs-create-filesystem.md[Create an Amazon EFS file system for Amazon EKS] on [.noloc]`GitHub`.
 


### PR DESCRIPTION
There was a typo on the documentation where Step 3 provided a Note stating that Fargate does not require the creation of the EFS CSI Driver where it should listed under Step 2

*Issue #, if available:*

Step 3 provides guidance on creating an EFS Volume and provides note stating that this step is not necessary for Fargate and Fargate does not require installation of EFS CSI Driver -- this should be outlined in Step 2 instead.

*Description of changes:*

Proposed movement of Note to Step 2 instead of Step 3 as it is misleading.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
