### PR TITLE
Update platform-versions.adoc

### DIFF
--- a/latest/ug/clusters/platform-versions.adoc
+++ b/latest/ug/clusters/platform-versions.adoc
@@ -44,7 +44,7 @@ The following admission controllers are enabled for all `1.32` platform versions
 | Release notes
 | Release date
 
-| `1.31.0`
+| `1.32.0`
 | `eks.2`
 | Initial release of Kubernetes version `1.32` for EKS. For more information, see <<kubernetes-1.32>>.
 | January 2025


### PR DESCRIPTION
Kubernetes version under the 1.32 section was incorrect. Fixed to reflect the correct version

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
