### PR TITLE
update latest/ug/nodes/al2023.adoc to include documentation and examp…

### DIFF
--- a/latest/ug/nodes/al2023.adoc
+++ b/latest/ug/nodes/al2023.adoc
@@ -32,6 +32,26 @@ spec:
 ----
 +
 In AL2, the metadata from these parameters was discovered from the Amazon EKS `DescribeCluster` API call. With AL2023, this behavior has changed since the additional API call risks throttling during large node scale ups. This change doesn't affect you if you're using managed node groups without a launch template or if you're using [.noloc]`Karpenter`. For more information on `certificateAuthority` and service `cidr`, see ` link:eks/latest/APIReference/API_DescribeCluster.html[DescribeCluster,type="documentation"]` in the _Amazon EKS API Reference_.
+* For AL2023, `nodeadm` also changes the format to apply parameters to the `kubelet` for each node using https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/#nodeconfigspec[`NodeConfigSpec`], in AL2 this was done with the `--kubelet-extra-args` parameter. This is commonly used to add labels and taints to nodes. An example below shows applying `maxPods` and `--node-labels`  to the node.
++
+[source,yaml,subs="verbatim,attributes"]
+----
+---
+apiVersion: node.eks.aws/v1alpha1
+kind: NodeConfig
+spec:
+  cluster:
+    name: test-cluster
+    apiServerEndpoint: https://example.com
+    certificateAuthority: Y2VydGlmaWNhdGVBdXRob3JpdHk=
+    cidr: 10.100.0.0/16
+  kubelet:
+    config:
+      maxPods: 110
+    flags:
+      - --node-labels=karpenter.sh/capacity-type=on-demand,karpenter.sh/nodepool=test
+----
++
 * [.noloc]`Docker` isn't supported in AL2023 for all supported Amazon EKS versions. Support for [.noloc]`Docker` has ended and been removed with Amazon EKS version `1.24` or greater in AL2. For more information on deprecation, see <<dockershim-deprecation>>.
 * Amazon VPC CNI version `1.16.2` or greater is required for AL2023.
 * AL2023 requires `IMDSv2` by default. `IMDSv2` has several benefits that help improve security posture. It uses a session-oriented authentication method that requires the creation of a secret token in a simple HTTP PUT request to start the session. A session's token can be valid for anywhere between 1 second and 6 hours. For more information on how to transition from `IMDSv1` to `IMDSv2`, see link:AWSEC2/latest/UserGuide/instance-metadata-transition-to-version-2.html[Transition to using Instance Metadata Service Version 2,type="documentation"] and link:security/get-the-full-benefits-of-imdsv2-and-disable-imdsv1-across-your-aws-infrastructure[Get the full benefits of IMDSv2 and disable IMDSv1 across your {aws} infrastructure,type="blog"]. If you would like to use `IMDSv1`, you can still do so by manually overriding the settings using instance metadata option launch properties.

--- a/latest/ug/nodes/al2023.adoc
+++ b/latest/ug/nodes/al2023.adoc
@@ -31,8 +31,8 @@ spec:
     cidr: 10.100.0.0/16
 ----
 +
-In AL2, the metadata from these parameters was discovered from the Amazon EKS `DescribeCluster` API call. With AL2023, this behavior has changed since the additional API call risks throttling during large node scale ups. This change doesn't affect you if you're using managed node groups without a launch template or if you're using [.noloc]`Karpenter`. For more information on `certificateAuthority` and service `cidr`, see ` link:eks/latest/APIReference/API_DescribeCluster.html[DescribeCluster,type="documentation"]` in the _Amazon EKS API Reference_.
-* For AL2023, `nodeadm` also changes the format to apply parameters to the `kubelet` for each node using https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/#nodeconfigspec[`NodeConfigSpec`], in AL2 this was done with the `--kubelet-extra-args` parameter. This is commonly used to add labels and taints to nodes. An example below shows applying `maxPods` and `--node-labels`  to the node.
+In AL2, the metadata from these parameters was discovered from the Amazon EKS `DescribeCluster` API call. With AL2023, this behavior has changed since the additional API call risks throttling during large node scale ups. This change doesn't affect you if you're using managed node groups without a launch template or if you're using [.noloc]`Karpenter`. For more information on `certificateAuthority` and service `cidr`, see link:eks/latest/APIReference/API_DescribeCluster.html[`DescribeCluster`,type="documentation"] in the _Amazon EKS API Reference_.
+* For AL2023, `nodeadm` also changes the format to apply parameters to the `kubelet` for each node using https://awslabs.github.io/amazon-eks-ami/nodeadm/doc/api/#nodeconfigspec[`NodeConfigSpec`]. In AL2, this was done with the `--kubelet-extra-args` parameter. This is commonly used to add labels and taints to nodes. An example below shows applying `maxPods` and `--node-labels` to the node.
 +
 [source,yaml,subs="verbatim,attributes"]
 ----


### PR DESCRIPTION
…le to apply kubelet parameters with nodeadm using NodeConfigSpec, this configuration is a change from AL2 and does not appear in elsewhere in EKS documentation.

*Issue #, if available:*
N/A

*Description of changes:*
Improve EKS AL2023 docs by including documentation and example of using `nodeadm` to apply `maxPods` and `--node-labels` parameters to node. This behavior has changed has from AL2 and it not referenced within EKS documentation. I used an example from [Karpenter docs](https://karpenter.sh/docs/concepts/nodeclasses/#al2023) as a basis for the configuration.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
