### PR TITLE
Update pod-identities.adoc

### DIFF
--- a/latest/ug/manage-access/aws-access/pod-identities.adoc
+++ b/latest/ug/manage-access/aws-access/pod-identities.adoc
@@ -91,7 +91,7 @@ Turn on EKS Pod Identities by completing the following procedures:
 * The EKS Pod Identity Agent uses the `hostNetwork` of the node and it uses port `80` and port `2703` on a link-local address on the node. This address is `169.254.170.23` for [.noloc]`IPv4` and `[fd00:ec2::23]` for [.noloc]`IPv6` clusters.
 +
 If you disable `IPv6` addresses, or otherwise prevent localhost `IPv6` IP addresses, the agent can't start. To start the agent on nodes that can't use `IPv6`, follow the steps in <<pod-id-agent-config-ipv6>> to disable the `IPv6` configuration.
-
+* If your Pods use a proxy, you must ensure you add `169.254.170.23` for [.noloc]`IPv4` and `[fd00:ec2::23]` for [.noloc]`IPv6` in the `no_proxy`/`NO_PROXY` environment variables injected into the pods. Otherwise requests from the application pods to the `eks-pod-identity-agent` DaemonSets would fail as the requests would be sent to the proxy and the proxy wouldn't be able to route the IP. 
 
 [#pod-id-cluster-versions]
 === EKS Pod Identity cluster versions


### PR DESCRIPTION
Include considerations on using Pod Identity with proxied EKS environments

*Issue #, if available:*
N/A

*Description of changes:*
Added an additional bullet point to the considerations around using proxies with the EKS Pod Identity Agent. If we don't add the EKS Pod Identity IPs to the no_proxy environment variables than this effectively breaks Pod Identities since they won't be able to call the eks-pod-identity-agent DaemonSet pods as the requests destined for these pods would be proxied and would not be routable by the proxy.

P.S. Didn't mean to close #872, was cleaning up my repositories for forgot this was linked to the PR. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
