### PR TITLE
Update ebs-csi.adoc

### DIFF
--- a/latest/ug/storage/ebs-csi.adoc
+++ b/latest/ug/storage/ebs-csi.adoc
@@ -27,7 +27,7 @@ The https://github.com/kubernetes-sigs/aws-ebs-csi-driver/[Amazon Elastic Block 
 * You can run the Amazon EBS CSI controller on Fargate nodes, but the Amazon EBS CSI node [.noloc]`DaemonSet` can only run on Amazon EC2 instances.
 * Amazon EBS volumes and the Amazon EBS CSI driver are not compatible with Amazon EKS Hybrid Nodes.
 * Support will be provided for the latest add-on version and one prior version. Bugs or vulnerabilities found in the latest version will be backported to the previous release in a new minor version.
-
+* Only PVs created from a Storage Class using `ebs.csi.eks.amazonaws.com` as the provisioner can be mounted on nodes created by EKS Auto mode. Existing PVs must be migrated to the new Storage Class using a volume snapshot.
 
 [IMPORTANT]
 ====

--- a/latest/ug/storage/ebs-csi.adoc
+++ b/latest/ug/storage/ebs-csi.adoc
@@ -24,10 +24,10 @@ The https://github.com/kubernetes-sigs/aws-ebs-csi-driver/[Amazon Elastic Block 
 
 * You do not need to install the Amazon EBS CSI controller on EKS Auto Mode clusters. 
 * You can't mount Amazon EBS volumes to Fargate [.noloc]`Pods`.
-* You can run the Amazon EBS CSI controller on Fargate nodes, but the Amazon EBS CSI node [.noloc]`DaemonSet` can only run on Amazon EC2 instances.
+* You can run the Amazon EBS CSI controller on Fargate nodes, but the Amazon EBS CSI node `DaemonSet` can only run on Amazon EC2 instances.
 * Amazon EBS volumes and the Amazon EBS CSI driver are not compatible with Amazon EKS Hybrid Nodes.
 * Support will be provided for the latest add-on version and one prior version. Bugs or vulnerabilities found in the latest version will be backported to the previous release in a new minor version.
-* Only PVs created from a Storage Class using `ebs.csi.eks.amazonaws.com` as the provisioner can be mounted on nodes created by EKS Auto mode. Existing PVs must be migrated to the new Storage Class using a volume snapshot.
+* Only platform versions created from a storage class using `ebs.csi.eks.amazonaws.com` as the provisioner can be mounted on nodes created by EKS Auto Mode. Existing platform versions must be migrated to the new storage class using a volume snapshot.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Only PVs created from a storage class referencing the `ebs.csi.eks.amazonaws.com` can be mounted on EKS Auto mode nodes. Updated docs to make this more clear

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
