### PR TITLE
Update IAM policy requirements for EKS worker nodes

### DIFF
--- a/latest/ug/security/iam-reference/create-node-role.adoc
+++ b/latest/ug/security/iam-reference/create-node-role.adoc
@@ -17,7 +17,7 @@ Before you create nodes, you must create an IAM role with the following permissi
 
 
 * Permissions for the `kubelet` to describe Amazon EC2 resources in the VPC, such as provided by the link:aws-managed-policy/latest/reference/AmazonEKSWorkerNodePolicy.html[AmazonEKSWorkerNodePolicy,type="documentation"] policy. This policy also provides the permissions for the Amazon EKS Pod Identity Agent.
-* Permissions for the `kubelet` to use container images from Amazon Elastic Container Registry (Amazon ECR), such as provided by the link:aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryPullOnly.html[AmazonEC2ContainerRegistryPullOnly,type="documentation"] policy. The permissions to use container images from Amazon Elastic Container Registry (Amazon ECR) are required because the built-in add-ons for networking run pods that use container images from Amazon ECR.
+* Permissions for the `kubelet` to use container images from Amazon Elastic Container Registry (Amazon ECR), such as provided by the link:aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryPullOnly.html[AmazonEC2ContainerRegistryPullOnly,type="documentation"] and link:aws-managed-policy/latest/reference/AmazonEC2ContainerRegistryReadOnly.html[AmazonEC2ContainerRegistryReadOnly,type="documentation"] policies. The permissions to use container images from Amazon Elastic Container Registry (Amazon ECR) are required because the built-in add-ons for networking run pods that use container images from Amazon ECR.
 * (Optional) Permissions for the Amazon EKS Pod Identity Agent to use the `eks-auth:AssumeRoleForPodIdentity` action to retrieve credentials for pods. If you don't use the link:aws-managed-policy/latest/reference/AmazonEKSWorkerNodePolicy.html[AmazonEKSWorkerNodePolicy,type="documentation"], then you must provide this permission in addition to the EC2 permissions to use EKS Pod Identity.
 * (Optional) If you don't use IRSA or EKS Pod Identity to give permissions to the VPC CNI pods, then you must provide  permissions for the VPC CNI on the instance role. You can use either the link:aws-managed-policy/latest/reference/AmazonEKS_CNI_Policy.html[`AmazonEKS_CNI_Policy`,type="documentation"] managed policy (if you created your cluster with the `IPv4` family) or an <<cni-iam-role-create-ipv6-policy,IPv6 policy that you create>> (if you created your cluster with the `IPv6` family). Rather than attaching the policy to this role however, we recommend that you attach the policy to a separate role used specifically for the Amazon VPC CNI add-on. For more information about creating a separate role for the Amazon VPC CNI add-on, see <<cni-iam-role>>.
 
@@ -36,7 +36,7 @@ You can use the following procedure to check and see if your account already has
 . In the left navigation pane, choose *Roles*.  
 . Search the list of roles for `eksNodeRole`, `AmazonEKSNodeRole`, or `NodeInstanceRole`. If a role with one of those names doesn't exist, then see <<create-worker-node-role>> to create the role. If a role that contains `eksNodeRole`, `AmazonEKSNodeRole`, or `NodeInstanceRole` does exist, then select the role to view the attached policies.
 . Choose *Permissions*.
-. Ensure that the *AmazonEKSWorkerNodePolicy* and *AmazonEC2ContainerRegistryPullOnly* managed policies are attached to the role or a custom policy is attached with the minimal permissions.
+. Ensure that the *AmazonEKSWorkerNodePolicy*, *AmazonEC2ContainerRegistryPullOnly* and *AmazonEC2ContainerRegistryReadOnly* managed policies are attached to the role or a custom policy is attached with the minimal permissions.
 +
 NOTE: If the *AmazonEKS_CNI_Policy* policy is attached to the role, we recommend removing it and attaching it to an IAM role that is mapped to the `aws-node` [.noloc]`Kubernetes` service account instead. For more information, see <<cni-iam-role>>.
 . Choose *Trust relationships*, and then choose *Edit trust policy*.
@@ -86,6 +86,9 @@ You can create the node IAM role with the {aws-management-console} or the {aws} 
 ... Choose *Clear filters*.  
 ... In the *Filter policies* box, enter `AmazonEC2ContainerRegistryPullOnly`.
 ... Select the check box to the left of *AmazonEC2ContainerRegistryPullOnly* in the search results.
+... Choose *Clear filters*. 
+... In the *Filter policies* box, enter `AmazonEC2ContainerRegistryReadOnly`.
+... Select the check box to the left of *AmazonEC2ContainerRegistryReadOnly* in the search results.
 +
 Either the *AmazonEKS_CNI_Policy* managed policy, or an <<cni-iam-role-create-ipv6-policy,IPv6 policy>> that you create must also be attached to either this role or to a different role that's mapped to the `aws-node` [.noloc]`Kubernetes` service account. We recommend assigning the policy to the role associated to the [.noloc]`Kubernetes` service account instead of assigning it to this role. For more information, see <<cni-iam-role>>.
 ... Choose *Next*.


### PR DESCRIPTION
This PR updates the documentation to clarify that both the AmazonEC2ContainerRegistryPullOnly and AmazonEC2ContainerRegistryReadOnly policies are required for EKS worker nodes. 
The documentation previously mentioned only the AmazonEC2ContainerRegistryPullOnly policy,  but during node group creation, the AmazonEC2ContainerRegistryReadOnly policy is also required.

*Issue #, if available:*

*Description of changes:*
- Added AmazonEC2ContainerRegistryReadOnly policy requirement alongside AmazonEC2ContainerRegistryPullOnly.
- Updated instructions to reflect the need for both policies when creating a worker node role.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
