### PR TITLE
Minor fixes and simplification of hybrid nodes upgrade instructions

### DIFF
--- a/latest/ug/nodes/hybrid-nodes-upgrade.adoc
+++ b/latest/ug/nodes/hybrid-nodes-upgrade.adoc
@@ -149,7 +149,7 @@ kubectl uncordon NODE_NAME
 +
 [source,yaml,subs="verbatim,attributes"]
 ----
-kubectl get nodes -o -w
+kubectl get nodes -o wide -w
 ----
 
 

--- a/latest/ug/nodes/hybrid-nodes-upgrade.adoc
+++ b/latest/ug/nodes/hybrid-nodes-upgrade.adoc
@@ -39,23 +39,22 @@ Cutover migration upgrades refer to the process of creating new hybrid nodes on 
 . Connect your new hosts as hybrid nodes following the <<hybrid-nodes-join>> steps. When running the `nodeadm install` command, use your target Kubernetes version.
 . Enable communication between the new hybrid nodes on the target Kubernetes version and your hybrid nodes on the old Kubernetes version. This configuration allows pods to communicate with each other while you are migrating your workload to the hybrid nodes on the target Kubernetes version.
 . Confirm your hybrid nodes on your target Kubernetes version successfully joined your cluster and have status Ready.
-. Use the following command to taint each of the nodes that you want to remove with `NoSchedule`. This is so that new pods aren't scheduled or rescheduled on the nodes that you are replacing. For more information, see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Taints and Tolerations] in the Kubernetes documentation. Replace `NODE_NAME` with the name of the hybrid nodes on the old Kubernetes version.
+. Use the following command to mark each of the nodes that you want to remove as unschedulable. This is so that new pods aren't scheduled or rescheduled on the nodes that you are replacing. For more information, see https://kubernetes.io/docs/reference/kubectl/generated/kubectl_cordon/[kubectl cordon] in the Kubernetes documentation. Replace `NODE_NAME` with the name of the hybrid nodes on the old Kubernetes version.
 +
 [source,yaml,subs="verbatim,attributes,quotes"]
 ----
-kubectl taint nodes [.replaceable]`NODE_NAME` key=value:NoSchedule
+kubectl cordon [.replaceable]`NODE_NAME`
 ----
 +
-You can identify and taint all of the nodes of a particular Kubernetes version (in this case, `1.28`) with the following code snippet.
+You can identify and cordon all of the nodes of a particular Kubernetes version (in this case, `1.28`) with the following code snippet.
 +
 [source,yaml,subs="verbatim,attributes"]
 ----
 K8S_VERSION=1.28
-nodes=$(kubectl get nodes -o jsonpath="{.items[?(@.status.nodeInfo.kubeletVersion==\"v$K8S_VERSION\")].metadata.name}")
-for node in ${nodes[@]}
+for node in $(kubectl get nodes -o json | jq --arg K8S_VERSION "$K8S_VERSION" -r '.items[] | select(.status.nodeInfo.kubeletVersion | match("\($K8S_VERSION)")).metadata.name')
 do
-    echo "Tainting $node"
-    kubectl taint nodes $node key=value:NoSchedule
+    echo "Cordoning $node"
+    kubectl cordon $node
 done
 ----
 . If your current deployment is running fewer than two CoreDNS replicas on your hybrid nodes, scale out the deployment to at least two replicas. It is recommended to run at least two CoreDNS replicas on hybrid nodes for resiliency during normal operations.
@@ -76,8 +75,7 @@ You can identify and drain all of the nodes of a particular Kubernetes version (
 [source,yaml,subs="verbatim,attributes"]
 ----
 K8S_VERSION=1.28
-nodes=$(kubectl get nodes -o jsonpath="{.items[?(@.status.nodeInfo.kubeletVersion==\"v$K8S_VERSION\")].metadata.name}")
-for node in ${nodes[@]}
+for node in $(kubectl get nodes -o json | jq --arg K8S_VERSION "$K8S_VERSION" -r '.items[] | select(.status.nodeInfo.kubeletVersion | match("\($K8S_VERSION)")).metadata.name')
 do
     echo "Draining $node"
     kubectl drain $node --ignore-daemonsets --delete-emptydir-data
@@ -103,11 +101,10 @@ You can identify and delete all of the nodes of a particular Kubernetes version 
 [source,yaml,subs="verbatim,attributes"]
 ----
 K8S_VERSION=1.28
-nodes=$(kubectl get nodes -o jsonpath="{.items[?(@.status.nodeInfo.kubeletVersion==\"v$K8S_VERSION\")].metadata.name}")
-for node in ${nodes[@]}
+for node in $(kubectl get nodes -o json | jq --arg K8S_VERSION "$K8S_VERSION" -r '.items[] | select(.status.nodeInfo.kubeletVersion | match("\($K8S_VERSION)")).metadata.name')
 do
     echo "Deleting $node"
-    kubectl delete node $node 
+    kubectl delete node $node
 done
 ----
 

--- a/latest/ug/nodes/hybrid-nodes-upgrade.adoc
+++ b/latest/ug/nodes/hybrid-nodes-upgrade.adoc
@@ -117,11 +117,11 @@ done
 
 The in-place upgrade process refers to using `nodeadm upgrade` to upgrade the Kubernetes version for hybrid nodes without using new physical or virtual hosts and a cutover migration strategy. The `nodeadm upgrade` process shuts down the existing older Kubernetes components running on the hybrid node, uninstalls the existing older Kubernetes components, installs the new target Kubernetes components, and starts the new target Kubernetes components. It is strongly recommend to upgrade one node at a time to minimize impact to applications running on the hybrid nodes. The duration of this process depends on your network bandwidth and latency.
 
-. Use the following command to taint the node you are upgrading with `NoSchedule`. This is so that new pods aren't scheduled or rescheduled on the node that you are upgrading. For more information, see https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/[Taints and Tolerations] in the Kubernetes documentation. Replace `NODE_NAME` with the name of the hybrid node you are upgrading
+. Use the following command to mark the node you are upgrading as unschedulable. This is so that new pods aren't scheduled or rescheduled on the node that you are upgrading. For more information, see https://kubernetes.io/docs/reference/kubectl/generated/kubectl_cordon/[kubectl cordon] in the Kubernetes documentation. Replace `NODE_NAME` with the name of the hybrid node you are upgrading
 +
 [source,yaml,subs="verbatim,attributes"]
 ----
-kubectl taint nodes NODE_NAME key=value:NoSchedule
+kubectl cordon NODE_NAME
 ----
 
 . Drain the node you are upgrading with the following command. For more information on draining nodes, see https://kubernetes.io/docs/tasks/administer-cluster/safely-drain-node/[Safely Drain a Node] in the Kubernetes documentation. Replace `NODE_NAME` with the name of the hybrid node you are upgrading.
@@ -141,7 +141,6 @@ nodeadm upgrade K8S_VERSION -c file://nodeConfig.yaml
 +
 [source,yaml,subs="verbatim,attributes,quotes"]
 ----
-kubectl taint nodes NODE_NAME key=value:NoSchedule-
 kubectl uncordon NODE_NAME
 ----
 


### PR DESCRIPTION
*Description of changes:* 
- Simplified steps for marking a node as unschedulable by using cordon instead of adding taints. Also, uncordon step is missing in the in-place upgrade instructions on the live site, but I see it has been added recently to the markdown in git, but not yet published.
- Fixed command for checking status of hybrid nodes after upgrade.
- Fix command to identify all nodes of a particular Kubernetes version in cutover migration upgrade instructions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
