### PR TITLE
Update auto-networking.adoc

### DIFF
--- a/latest/ug/automode/auto-networking.adoc
+++ b/latest/ug/automode/auto-networking.adoc
@@ -36,6 +36,7 @@ EKS Auto Mode supports:
 * EKS Network Policies.
 * The `HostPort` and `HostNetwork` options for Kubernetes Pods.
 * Pods in public or private subnets.
+* Automatic subnet CIDR allocation when prefix ranges are reserved.
 
 EKS Auto Mode does *not* support:
 


### PR DESCRIPTION
Clarifies that EKS Auto Mode can automatically allocate subnet CIDRs when prefix ranges are reserved. This helps users better understand the automatic CIDR management capabilities.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
