### PR TITLE
add affinity and disable Envoy for Cilium on hybrid nodes

### DIFF
--- a/latest/ug/nodes/hybrid-nodes-cni.adoc
+++ b/latest/ug/nodes/hybrid-nodes-cni.adoc
@@ -97,8 +97,19 @@ ipam:
     clusterPoolIPv4PodCIDRList:
     - POD_CIDR
 operator:
+  affinity:
+    nodeAffinity:
+      requiredDuringSchedulingIgnoredDuringExecution:
+        nodeSelectorTerms:
+        - matchExpressions:
+          - key: eks.amazonaws.com/compute-type
+            operator: In
+            values:
+              - hybrid
   unmanagedPodWatcher:
     restart: false
+envoy:
+  enabled: false
 ----
 
 . Install Cilium on your cluster. Replace `CILIUM_VERSION` with your desired Cilium version. It is recommended to run the latest patch version for your Cilium minor version. You can find the latest patch release for a given minor Cilium release in the https://github.com/cilium/cilium#stable-releases[Stable Releases section] of the Cilium documentation. If you are enabling BGP for your deployment, add the `--set bgpControlPlane.enabled=true` flag in the command below. If you are using a specific kubeconfig file, use the `--kubeconfig` flag with the Helm install command.


### PR DESCRIPTION
*Description of changes:* Fixes for Hybrid Nodes with Cilium, in clusters with EC2 nodes. Adding affinity to the operator and disabling the unused Envoy so that all of Cillium runs on hybrid nodes.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
