### PR TITLE
Correct Auto Mode ELB Doc - Remove namespace from IngressClass yaml

### DIFF
--- a/latest/ug/automode/auto-elb-example.adoc
+++ b/latest/ug/automode/auto-elb-example.adoc
@@ -131,7 +131,6 @@ First, create the `IngressClass`. Create a file named `04-ingressclass.yaml`:
 apiVersion: networking.k8s.io/v1
 kind: IngressClass
 metadata:
-  namespace: game-2048
   labels:
     app.kubernetes.io/name: LoadBalancerController
   name: alb


### PR DESCRIPTION
IngressClass is a cluster scope resource.

*Issue #, if available:*

*Description of changes:*

- Remove `namespace: game-2048` from IngressClass yaml.
- IngressClass is a cluster scoped resource 

![Screenshot 2025-02-23 at 6 38 01 pm](https://github.com/user-attachments/assets/6dac3d90-dcaa-49f2-a7bf-c2dc3f8eac33)



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
