### PR TITLE
Update addon-id-troubleshoot.adoc for EKS Pod Identity.

### DIFF
--- a/latest/ug/workloads/addon-id-troubleshoot.adoc
+++ b/latest/ug/workloads/addon-id-troubleshoot.adoc
@@ -39,3 +39,8 @@ aws iam get-role --role-name <role-name> --query Role.AssumeRolePolicyDocument
 * The service account name in the pod identity association matches the service account name used by the add-on. 
 +
 ** For information about the available add-ons, see <<workloads-add-ons-available-eks>>.
++
+* Check configuration of MutatingWebhookConfiguration named `pod-identity-webhook`
+** `admissionReviewVersions` of the webhook needs to be `v1beta1` and doesn't work with `v1`.
+
+


### PR DESCRIPTION
*Description of changes:*
Adds additional debug step for EKS pod identity implementation.

Hey found this out after spending time debugging with 3 different AWS Support engineers. Everything was setup using the  AWS Docs from here https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html . The same config was working on the support engineer's cluster but failing on our cluster.  Then we ran this query on the Cloudwatch Log insights on the eks cluster logs

```
fields @timestamp, @message
| filter @logStream like /kube-apiserver/ and @logStream not like /kube-apiserver-audit/
| filter @message like /failed calling webhook/
| sort @timestamp desc
```
Which showed us some errors in the mutating webhooks then we compared the YAML of ours and their cluster's pod-identity-webhook MutatingWebhookConfiguration which led us to this discovery. Their webhook was on v1Beta1 while ours was on V1.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
