### PR TITLE
Update efs-csi.adoc to include a warning about self-managed CSI Drive…

### DIFF
--- a/latest/ug/storage/efs-csi.adoc
+++ b/latest/ug/storage/efs-csi.adoc
@@ -183,9 +183,7 @@ We recommend that you install the Amazon EFS CSI driver through the Amazon EKS a
 
 [IMPORTANT]
 ====
-
-Before adding the Amazon EFS driver as an Amazon EKS add-on, confirm that you don't have a self-managed version of the driver installed on your cluster. If so, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#uninstalling-the-amazon-efs-csi-driver[Uninstalling a self-managed Amazon EFS CSI driver] on GitHub.  
-
+Before adding the Amazon EFS driver as an Amazon EKS add-on, confirm that you don't have a self-managed version of the driver installed on your cluster. If so, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#uninstalling-the-amazon-efs-csi-driver[Uninstalling the Amazon EFS CSI Driver] on GitHub.  
 ====
 
 Alternatively, if you want a self-managed installation of the Amazon EFS CSI driver, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#installation[Installation] on GitHub.

--- a/latest/ug/storage/efs-csi.adoc
+++ b/latest/ug/storage/efs-csi.adoc
@@ -181,6 +181,13 @@ aws iam attach-role-policy \
 
 We recommend that you install the Amazon EFS CSI driver through the Amazon EKS add-on. To add an Amazon EKS add-on to your cluster, see <<creating-an-add-on>>. For more information about add-ons, see <<eks-add-ons>>. If you're unable to use the Amazon EKS add-on, we encourage you to submit an issue about why you can't to the https://github.com/aws/containers-roadmap/issues[Containers roadmap GitHub repository].
 
+[IMPORTANT]
+====
+
+Before adding the Amazon EFS driver as an Amazon EKS add-on, confirm that you don't have a self-managed version of the driver installed on your cluster. If so, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#uninstalling-the-amazon-efs-csi-driver[Uninstalling a self-managed Amazon EFS CSI driver] on GitHub.  
+
+====
+
 Alternatively, if you want a self-managed installation of the Amazon EFS CSI driver, see https://github.com/kubernetes-sigs/aws-efs-csi-driver/blob/master/docs/README.md#installation[Installation] on GitHub.
 
 [#efs-create-filesystem]


### PR DESCRIPTION
…r addons

*Issue #, if available:*

*Description of changes:*
Adding a warning for users to ensure a self managed driver isn't already installed on the cluster. This corresponding [EFS CSI Driver pull request](https://github.com/kubernetes-sigs/aws-efs-csi-driver/pull/1597) should be merged before this one to ensure all links are working properly.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
