### PR TITLE
adds ecr api endpoint to hybrid networking

### DIFF
--- a/latest/ug/nodes/hybrid-nodes-networking.adoc
+++ b/latest/ug/nodes/hybrid-nodes-networking.adoc
@@ -55,6 +55,11 @@ You must have access to the following domains during the installation process wh
 |HTTPS
 |443
 
+|link:general/latest/gr/ecr.html[ECR service endpoints,type="documentation"]
+|\https://api.ecr.[.replaceable]`region`.amazonaws.com
+|HTTPS
+|443
+
 |EKS ECR endpoints
 |See <<add-ons-images>> for regional endpoints.
 |HTTPS


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/eks-hybrid/issues/367

*Description of changes:*

A github user ran into an issue where the api.ecr endpoint was being blocked by their firewall and we were not calling this out in our docs.  This adds it, along with the link to the ecr page, to our networking requirements table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
