### PR TITLE
Update auto mode does not support doc about IPv6 clusters

### DIFF
--- a/latest/ug/automode/auto-networking.adoc
+++ b/latest/ug/automode/auto-networking.adoc
@@ -47,7 +47,7 @@ EKS Auto Mode does *not* support:
 * Other configurations supported by the open-source {aws} CNI.
 * Network Policy configurations such as conntrack timer customization (default is 300s).
 * Exporting network event logs to CloudWatch.
-* Egress IPv4 from Pods in clusters using IPv6.
+* When running an EKS cluster in IPv6 mode, IPv4 egress traffic from pods is not supported 
 
 
 [#auto-lb-consider]

--- a/latest/ug/automode/auto-networking.adoc
+++ b/latest/ug/automode/auto-networking.adoc
@@ -47,6 +47,7 @@ EKS Auto Mode does *not* support:
 * Other configurations supported by the open-source {aws} CNI.
 * Network Policy configurations such as conntrack timer customization (default is 300s).
 * Exporting network event logs to CloudWatch.
+* Egress IPv4 from Pods in clusters using IPv6.
 
 
 [#auto-lb-consider]


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Auto Mode Clusters using IPv6 works with Egress IPv6 from Pods, however, Egress IPv4 from Pods not supported at this time.

Reference to Case ID 174051352500894

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
