### PR TITLE
fix: aws eks update-cluster-config example

### DIFF
--- a/latest/ug/automode/set-builtin-node-pools.adoc
+++ b/latest/ug/automode/set-builtin-node-pools.adoc
@@ -65,7 +65,6 @@ Use the following command to disable both built-in NodePools:
 ----
 aws eks update-cluster-config \
   --name <cluster-name> \
-  --compute-config '{"nodePools": []}'
   --compute-config '{
   "enabled": true,
   "nodePools": []


### PR DESCRIPTION
Remove a redundant line in the example of `aws eks update-cluster-config` command to disable default node pools
