### PR TITLE
Remove duplicated role entry en create-node-class.adoc

### DIFF
--- a/latest/ug/automode/create-node-class.adoc
+++ b/latest/ug/automode/create-node-class.adoc
@@ -145,11 +145,6 @@ spec:
     iops: 3000      # Range: 3000-16000
     throughput: 125 # Range: 125-1000
 
-  # IAM role to use for EC2 instance role
-  # If unspecified, EKS will create a role
-  # If specified, role requires access entry described above
-  role: arn:aws:iam::123456789012:role/MyNodeRole  
-  
   # Optional: Additional EC2 tags
   tags:
     Environment: "production"


### PR DESCRIPTION
Remove a duplicated reference to key `role` in the node class specification example. I think that the second one is incorrect, as it has an arn as value. Please double check with the actual node class specification.
