### PR TITLE
Update auto-networking.adoc

### DIFF
--- a/latest/ug/automode/auto-networking.adoc
+++ b/latest/ug/automode/auto-networking.adoc
@@ -62,4 +62,4 @@ For more information, see <<auto-configure-alb>> or <<auto-configure-nlb>>.
 * EKS Auto Mode only supports Security Group Mode for Network Load Balancers. 
 * {aws} does not support migrating load balancers from the self managed {aws} load balancer controller to management by EKS Auto Mode.
 * The `networking.ingress.ipBlock` field in `TargetGroupBinding` spec is not supported. 
-* If your worker nodes use custom security groups (not `+eks-cluster-sg-*+` naming pattern), your cluster role needs additional IAM permissions.  The default EKS-managed policy only allows EKS to modify security groups named `+eks-cluster-sg-*+`. Without permission to modify your custom security groups, EKS cannot add the required ingress rules that allow ALB/NLB traffic to reach your pods.
+* If your worker nodes use custom security groups (not `eks-cluster-sg-*` naming pattern), your cluster role needs additional IAM permissions.  The default EKS-managed policy only allows EKS to modify security groups named `eks-cluster-sg-*`. Without permission to modify your custom security groups, EKS cannot add the required ingress rules that allow ALB/NLB traffic to reach your pods.


### PR DESCRIPTION
Current formatting seems to be misinterpreted resulting in following output. Note  –0— and –1—  

```
If your worker nodes use custom security groups (not –0— naming pattern), your cluster role needs additional IAM permissions. The default EKS-managed policy only allows EKS to modify security groups named –1—. Without permission to modify your custom security groups, EKS cannot add the required ingress rules that allow ALB/NLB traffic to reach your pods. 
```

Trying to remove + sign to fix this formatting issue

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
