### PR TITLE
Fixed curl command in lbc-helm.adoc 

### DIFF
--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -59,7 +59,7 @@ Below example is referring to the {aws} Load Balancer Controller *v2.11.0* relea
 +
 [source,shell,subs="verbatim,attributes"]
 ----
-curl -O https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json
+curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
 ----
 ** If you are a non-standard {aws} partition, such as a Government or China region, https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/docs/install[review the policies on GitHub] and download the appropriate policy for your region.  
 . Create an IAM policy using the policy downloaded in the previous step. 


### PR DESCRIPTION
*Description of changes:*
The load balancer controller Helm instructions use the incorrect URL with "curl -O". This command will download the full web page:
curl -O https://github.com/kubernetes-sigs/aws-load-balancer-controller/blob/main/docs/install/iam_policy.json

Instead, the raw.githubusercontent URL should be used:
curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json

The updated command is the same as the one used in the load balancer controller manifest documentation.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
