### PR TITLE
Update lbc-helm.adoc

### DIFF
--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -44,7 +44,7 @@ Before starting this tutorial, you must install and configure the following tool
 [NOTE]
 ====
 
-Below example is referring to the {aws} Load Balancer Controller *v2.11.0* release version. For more information about all releases, see the https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/[{aws} Load Balancer Controller Release Page] on GitHub.
+Below example is referring to the {aws} Load Balancer Controller *v2.12.0* release version. For more information about all releases, see the https://github.com/kubernetes-sigs/aws-load-balancer-controller/releases/[{aws} Load Balancer Controller Release Page] on GitHub.
 
 ====
 
@@ -52,7 +52,7 @@ Below example is referring to the {aws} Load Balancer Controller *v2.11.0* relea
 +
 [source,shell,subs="verbatim,attributes"]
 ----
-curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.11.0/docs/install/iam_policy.json
+curl -O https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/v2.12.0/docs/install/iam_policy.json
 ----
 ** If you are a non-standard {aws} partition, such as a Government or China region, https://github.com/kubernetes-sigs/aws-load-balancer-controller/tree/main/docs/install[review the policies on GitHub] and download the appropriate policy for your region.  
 . Create an IAM policy using the policy downloaded in the previous step. 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated the doc to point to the latest version of AWS load balancer controller (v2.12.0). 

With v2.11.0, the `AWSLoadBalancerControllerIAMPolicy` was missing the `elasticloadbalancing:DescribeListenerAttributes` action and I was getting the following error on checking logs using 
`kubectl logs -f -n kube-system -l app.kubernetes.io/instance=aws-load-balancer-controller`:

```
{"level":"error","ts":"2025-03-18T13:30:29Z","msg":"Reconciler error","controller":"ingress","object":{"name":"ingress-2048","namespace":"game-2048"},"namespace":"game-2048","name":"ingress-2048","reconcileID":"ba17859b-d100-433b-a5e8-b96898f60628","error":"operation error Elastic Load Balancing v2: DescribeListenerAttributes, https response error StatusCode: 403, RequestID: d4521eb3-bc47-436a-87e7-93f5422d4578, api error AccessDenied: User: is not authorized to perform: elasticloadbalancing:DescribeListenerAttributes because no identity-based policy allows the elasticloadbalancing:DescribeListenerAttributes action"}
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
