### PR TITLE
Update fsx-ontap.adoc

### DIFF
--- a/latest/ug/storage/fsx-ontap.adoc
+++ b/latest/ug/storage/fsx-ontap.adoc
@@ -17,8 +17,8 @@ Amazon FSx for NetApp ONTAP is a storage service that allows you to launch and r
 
 [IMPORTANT]
 ====
-If you are using Amazon FSx for NetApp ONTAP alongside EBS CSI driver to provision EBS volumes you must ensure that you blacklist EBS devices in the multipath.conf file. For supported methods please see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/dm_multipath/config_file_blacklist#config_file_blacklist[Configuration File Blacklist]. An example has been provided below:
-====
+If you are using Amazon FSx for NetApp ONTAP alongside the Amazon EBS CSI driver to provision EBS volumes, you must ensure that you blacklist EBS devices in the `multipath.conf` file. For supported methods, see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/dm_multipath/config_file_blacklist#config_file_blacklist[Configuration File Blacklist]. Here is an example.
+
 [source,json,subs="verbatim,attributes"]
 ----
  defaults {
@@ -32,3 +32,4 @@ If you are using Amazon FSx for NetApp ONTAP alongside EBS CSI driver to provisi
         }
       }
 ----
+====

--- a/latest/ug/storage/fsx-ontap.adoc
+++ b/latest/ug/storage/fsx-ontap.adoc
@@ -13,3 +13,22 @@ The NetApp Trident allows Amazon EKS clusters to manage the lifecycle of persist
 The NetApp Trident provides dynamic storage orchestration using a Container Storage Interface (CSI) compliant driver. This allows Amazon EKS clusters to manage the lifecycle of persistent volumes (PVs) backed by Amazon FSx for NetApp ONTAP file systems. Note that the Amazon FSx for NetApp ONTAP CSI driver is not compatible with Amazon EKS Hybrid Nodes. To get started, see https://docs.netapp.com/us-en/trident/trident-use/trident-fsx.html[Use Trident with Amazon FSx for NetApp ONTAP] in the NetApp Trident documentation.
 
 Amazon FSx for NetApp ONTAP is a storage service that allows you to launch and run fully managed ONTAP file systems in the cloud. ONTAP is NetApp's file system technology that provides a widely adopted set of data access and data management capabilities. FSx for ONTAP provides the features, performance, and APIs of on-premises NetApp file systems with the agility, scalability, and simplicity of a fully managed {aws} service. For more information, see the link:fsx/latest/ONTAPGuide/what-is-fsx-ontap.html[FSx for ONTAP User Guide,type="documentation"].
+
+
+[IMPORTANT]
+====
+If you are using Amazon FSx for NetApp ONTAP alongside EBS CSI driver to provision EBS volumes you must ensure that you blacklist EBS devices in the multipath.conf file. For supported methods please see https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/dm_multipath/config_file_blacklist#config_file_blacklist[Configuration File Blacklist]. An example has been provided below:
+====
+[source,json,subs="verbatim,attributes"]
+----
+ defaults {
+        user_friendly_names yes
+        find_multipaths no
+      }
+      blacklist {
+        device {
+          vendor "NVME"
+          product "Amazon Elastic Block Store"
+        }
+      }
+----


### PR DESCRIPTION
Customers who are using FSx ONTAP alongside EBS CSI driver to provision EBS volumes for EKS workloads must ensure that EBS devices are blacklisted in the multipath.conf file otherwise the EBS volumes provisioned by EBS CSI driver will not mount successfully to pods.

*Issue #, if available:*
One of the [requirement](https://docs.netapp.com/us-en/trident/trident-docker/prereqs-docker.html#verify-the-requirements) for configuring trident is to enable multipath with the following:

```sudo mpathconf --enable --with_multipathd y --find_multipaths n```

As per above the --find_multipaths n sets find_multipaths no in /etc/multipath.conf as given below:

```# device-mapper-multipath configuration file

# For a complete list of the default configuration values, run either:
# # multipath -t
# or
# # multipathd show config

# For a list of configuration options with descriptions, see the
# multipath.conf man page.

defaults {
        user_friendly_names yes
        find_multipaths no
}

blacklist {
}
```
With above configuration for multipath, the OS will include all detected block devices for multipathing and lsblk will look like below whenever a new EBS volume is attached to the instance.
```
nvme2n1       259:5    0   1G  0 disk
└─mpathj      253:1    0   1G  0 mpath.  <-------look at the mpath device name in here
```
With this, for all action on the device like filesystem creation or lvm creation, we have to refer the storage with multipath device name /dev/mapper/mpathj instead of device name /dev/nvme2n1. The EBS CSI driver is not aware of this and it will try to perform volume actions using the /dev/nvme2n1 device name and such action will fail with errors given below:
```
couldnot format "/dev/nvme2n1" and mount it at "/var/lib/kubelet/plugins/kubernetes.io/
format of disk "/dev/nvme2n1" failed: type:("ext4") target:
/dev/nvme2n1 is apparently in use by the system; will not make a filesystem here!
```
The solution for this is to blacklist nvme storage devices by any of the methods mentioned in [here](https://docs.redhat.com/en/documentation/red_hat_enterprise_linux/7/html/dm_multipath/config_file_blacklist#config_file_blacklist). The one we have used is blacklisting by device type and added the following in /etc/multipath.conf
```
blacklist {
        device {
          vendor "NVME"
          product "Amazon Elastic Block Store"
}
}
```
Then restart ```systemctl restart multipathd```

*Description of changes:*
Added note, reference point, and example to include blacklist requirement for EBS devices provisioned by the EBS CSI driver so that customers are aware of this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
