### PR TITLE
Fix zsh globbing pattern in aws iam list-attached-role-policies query

### DIFF
--- a/latest/ug/manage-access/aws-access/pod-id-association.adoc
+++ b/latest/ug/manage-access/aws-access/pod-id-association.adoc
@@ -223,7 +223,7 @@ An example output is as follows.
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-aws iam list-attached-role-policies --role-name my-role --query AttachedPolicies[].PolicyArn --output text
+aws iam list-attached-role-policies --role-name my-role --query 'AttachedPolicies[].PolicyArn' --output text
 ----
 +
 An example output is as follows.


### PR DESCRIPTION
zsh interprets `[]` as a globbing pattern:

```
$ aws iam list-attached-role-policies --role-name my-role --query AttachedPolicies[].PolicyArn --output text
$ zsh: no matches found: AttachedPolicies[].PolicyArn
```

*Description of changes:*
Add quotes around `AttachedPolicies[].PolicyArn`