### PR TITLE
Update coredns-autoscaling.adoc

### DIFF
--- a/latest/ug/networking/coredns-autoscaling.adoc
+++ b/latest/ug/networking/coredns-autoscaling.adoc
@@ -37,9 +37,7 @@ A new Amazon EKS cluster. To deploy one, see <<getting-started>>. The cluster mu
 
 [source,bash,subs="verbatim,attributes"]
 ----
-aws eks describe-cluster
-              --name my-cluster --query cluster.version --output
-              text
+aws eks describe-cluster --name my-cluster --query cluster.version --output text
 ----
 
 [cols="1,1", options="header"]
@@ -266,7 +264,7 @@ aws eks update-addon --cluster-name my-cluster --addon-name coredns \
 +
 [source,shell,subs="verbatim,attributes"]
 ----
-aws eks describe-addon --cluster-name my-cluster --addon-name coredns \
+aws eks describe-addon --cluster-name my-cluster --addon-name coredns
 ----
 +
 If you see this line: `"status": "ACTIVE"`, then the rollout has completed and the add-on is using the new configuration in all of the CoreDNS pods. As you change the number of nodes and CPU cores of nodes in the cluster, Amazon EKS scales the number of replicas of the CoreDNS deployment.


### PR DESCRIPTION
Updating 2 commands which were wrongly typed

*Issue #, if available:*
1) aws eks describe-addon --cluster-name my-cluster --addon-name coredns \ >> Should not have \ in the end.
2) aws eks describe-cluster
              --name my-cluster --query cluster.version --output
              text

Above multiline isn't working. I replicated, though not working.

*Description of changes:*
1) Removed \ from the command
2) Made it to 1 line which worked.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
