### PR TITLE
chore: Add termination grace period note around defaulting NodePools

### DIFF
--- a/latest/ug/automode/create-node-pool.adoc
+++ b/latest/ug/automode/create-node-pool.adoc
@@ -221,3 +221,7 @@ By default, EKS Auto Mode:
 - Consolidates underutilized instances. 
 - Terminates instances after 720 hours. 
 - Sets a single disruption budget of 10% of nodes. 
+
+== Termination Grace Period
+
+When a terminationGracePeriod is not explicitly defined on an EKS Auto NodePool, the system automatically applies a default 24-hour termination grace period to the associated NodeClaim. While EKS Auto customers will not see a terminationGracePeriod defaulted in their custom NodePool configurations, they will observe this default value on the NodeClaim. The functionality remains consistent whether the grace period is explicitly set on the NodePool or defaulted on the NodeClaim, ensuring predictable node termination behavior across the cluster.

--- a/latest/ug/automode/create-node-pool.adoc
+++ b/latest/ug/automode/create-node-pool.adoc
@@ -224,4 +224,4 @@ By default, EKS Auto Mode:
 
 == Termination Grace Period
 
-When a terminationGracePeriod is not explicitly defined on an EKS Auto NodePool, the system automatically applies a default 24-hour termination grace period to the associated NodeClaim. While EKS Auto customers will not see a terminationGracePeriod defaulted in their custom NodePool configurations, they will observe this default value on the NodeClaim. The functionality remains consistent whether the grace period is explicitly set on the NodePool or defaulted on the NodeClaim, ensuring predictable node termination behavior across the cluster.
+When a `terminationGracePeriod` is not explicitly defined on an EKS Auto NodePool, the system automatically applies a default 24-hour termination grace period to the associated NodeClaim. While EKS Auto customers will not see a `terminationGracePeriod` defaulted in their custom NodePool configurations, they will observe this default value on the NodeClaim. The functionality remains consistent whether the grace period is explicitly set on the NodePool or defaulted on the NodeClaim, ensuring predictable node termination behavior across the cluster.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Adding a note for termination grace period defaulting on custom NodePools

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
