### PR TITLE
Update Helm setup instructions

### DIFF
--- a/latest/ug/automode/auto-migrate-karpenter.adoc
+++ b/latest/ug/automode/auto-migrate-karpenter.adoc
@@ -129,4 +129,4 @@ spec:
 
 == Step 8: Uninstall Karpenter from your cluster 
 
-The steps to remove Karpenter depend on how you installed it. For more information, see the https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#create-a-cluster-and-add-karpenter[Karpenter install instructions] and the https://helm.sh/docs/helm/helm_uninstall/[Helm Uninstall command].
+The steps to remove Karpenter depend on how you installed it. For more information, see the https://karpenter.sh/docs/getting-started/getting-started-with-karpenter/#create-a-cluster-and-add-karpenter[Karpenter install instructions].

--- a/latest/ug/automode/old/hpa_scaling.adoc
+++ b/latest/ug/automode/old/hpa_scaling.adoc
@@ -17,8 +17,8 @@ This guide shows you how Karpenter autoscales nodes in conjunction with HPA scal
 == Prerequisites
 
 * watch (https://formulae.brew.sh/formula/watch[Mac], https://www.powershellgallery.com/packages/Watch-Command/0.1.3[Windows])
-* https://kubernetes.io/docs/tasks/tools/#kubectl[kubectl]
-* https://helm.sh/docs/intro/install/[Helm]
+* <<install-kubectl,kubectl>>
+* <<helm,helm>>
 
 == 1. Deploy Metrics Server
 

--- a/latest/ug/cluster-management/cost-monitoring-kubecost.adoc
+++ b/latest/ug/cluster-management/cost-monitoring-kubecost.adoc
@@ -45,7 +45,7 @@ Learn how to <<removing-an-add-on,remove an EKS Add-on>>, such as Kubecost.
 
 * An existing Amazon EKS cluster. To deploy one, see <<getting-started>>.
 * The `kubectl` command line tool is installed on your device or {aws} CloudShell. The version can be the same as or up to one minor version earlier or later than the Kubernetes version of your cluster. For example, if your cluster version is `1.29`, you can use `kubectl` version `1.28`, `1.29`, or `1.30` with it. To install or upgrade `kubectl`, see <<install-kubectl>>.
-* Helm version 3.9.0 or later configured on your device or {aws} CloudShell. To install or update Helm, see <<helm>>.
+* https://helm.sh/docs/topics/version_skew/#supported-version-skew[Supported Helm versions] on your device or {aws} CloudShell. To install or update Helm, see <<helm>>.
 * Cluster version should be `1.21 (or higher)` and `1.31` is officially supported as of v2. Learn more at https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=installation-environment#ariaid-title2[Supported Kubernetes versions].
 * If your cluster is version `1.23` or later, you must have the <<ebs-csi,Store Kubernetes volumes with Amazon EBS>> installed on your cluster.
 

--- a/latest/ug/cluster-management/helm.adoc
+++ b/latest/ug/cluster-management/helm.adoc
@@ -57,15 +57,17 @@ sudo yum install openssl
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-helm version | cut -d + -f 1
+helm version --template='{{ .Version }}{{ "\n" }}'
 ----
 +
 An example output is as follows.
 +
 [source,bash,subs="verbatim,attributes"]
 ----
-v3.9.0
+v3.17.2
 ----
+. Make sure the version installed is compatible with your cluster version. Check https://helm.sh/docs/topics/version_skew/#supported-version-skew[Supported Version Skew] to learn more. For example, if you are running with `3.17.x`, supported Kubernetes version should not out of the range of `1.29.x` ~ `1.32.x`.
++
 . At this point, you can run any Helm commands (such as `helm install [.replaceable]``chart-name```) to install, modify, delete, or query Helm charts in your cluster. If you're new to Helm and don't have a specific chart to install, you can:
 +
 ** Experiment by installing an example chart. See https://helm.sh/docs/intro/quickstart#install-an-example-chart[Install an example chart] in the Helm https://helm.sh/docs/intro/quickstart/[Quickstart guide].

--- a/latest/ug/getting-started/setting-up.adoc
+++ b/latest/ug/getting-started/setting-up.adoc
@@ -18,7 +18,7 @@ To prepare for the command-line management of your Amazon EKS clusters, you need
 * Set up a development environment (optional)– Consider adding the following tools:
 +
 ** *Local deployment tool* – If you're new to Kubernetes, consider installing a local deployment tool like https://minikube.sigs.k8s.io/docs/[minikube] or https://kind.sigs.k8s.io/[kind]. These tools allow you to have an Amazon EKS cluster on your local machine for testing applications.
-** *Package manager* – https://helm.sh/docs/intro/install/[Helm] is a popular package manager for Kubernetes that simplifies the installation and management of complex packages. With Helm, it's easier to install and manage packages like the {aws} Load Balancer Controller on your Amazon EKS cluster.
+** *Package manager* – <<helm,helm>> is a popular package manager for Kubernetes that simplifies the installation and management of complex packages. With <<helm,Helm>>, it's easier to install and manage packages like the {aws} Load Balancer Controller on your Amazon EKS cluster.
 
 
 [#setting-up-next-steps]

--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -35,7 +35,7 @@ Before starting this tutorial, you must install and configure the following tool
 * Familiarity with Kubernetes https://kubernetes.io/docs/concepts/services-networking/service/[service] and https://kubernetes.io/docs/concepts/services-networking/ingress/[ingress] resources.
 
 
-* https://helm.sh/docs/helm/helm_install/[Helm] installed locally. 
+* <<helm,helm>> installed locally.
 
 
 [#lbc-helm-iam]

--- a/latest/ug/nodes/hybrid-nodes-cni.adoc
+++ b/latest/ug/nodes/hybrid-nodes-cni.adoc
@@ -72,7 +72,7 @@ Calico version `3.29.x` is supported and recommended for EKS Hybrid Nodes for ev
 
 == Install Cilium on hybrid nodes
 
-. Ensure that you have installed the Helm CLI on your command-line environment. See the https://helm.sh/docs/intro/quickstart/[Helm documentation] for installation instructions.
+. Ensure that you have installed the Helm CLI on your command-line environment. See the <<helm,setup helm>> for installation instructions.
 . Install the Cilium Helm repo.
 +
 [source,bash,subs="verbatim,attributes"]

--- a/latest/ug/observability/deploy-prometheus.adoc
+++ b/latest/ug/observability/deploy-prometheus.adoc
@@ -7,10 +7,10 @@ include::../attributes.txt[]
 
 [abstract]
 --
-As an alternative to using Amazon Managed Service for Prometheus, you can deploy Prometheus into your cluster with Helm V3.
+As an alternative to using Amazon Managed Service for Prometheus, you can deploy Prometheus into your cluster with https://helm.sh/docs/topics/version_skew/#supported-version-skew[supported Helm versions].
 --
 
-As an alternative to using Amazon Managed Service for Prometheus, you can deploy Prometheus into your cluster with Helm V3. If you already have Helm installed, you can check your version with the `helm version` command. Helm is a package manager for Kubernetes clusters. For more information about Helm and how to install it, see <<helm>>.
+As an alternative to using Amazon Managed Service for Prometheus, you can deploy Prometheus into your cluster with Helm. If you already have Helm installed, you can check your version with the `helm version` command. Helm is a package manager for Kubernetes clusters. For more information about Helm and how to install it, see <<helm>>.
 
 After you configure Helm for your Amazon EKS cluster, you can use it to deploy Prometheus with the following steps.
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Instruct user to setup [Supported Helm Versions](https://helm.sh/docs/topics/version_skew/#supported-version-skew).
* Remove Helm version pins, Kubernetes version changes from time to time, `helm-v3.9.0` can only support up to Kubernetes 1.21 version. Replaced with [Supported Helm versions](https://helm.sh/docs/topics/version_skew/#supported-version-skew) link instead.
* Unify the instructions of Helm CLI setup.
* Update command for the version check as `helm version | cut -d + -f 1` is not working for latest Helm version.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
