### PR TITLE
Add more `remoteNetworkConfig` update examples for hybrid nodes

### DIFF
--- a/latest/ug/nodes/hybrid-nodes-cluster-update.adoc
+++ b/latest/ug/nodes/hybrid-nodes-cluster-update.adoc
@@ -16,18 +16,14 @@ To enable an Amazon EKS cluster to use hybrid nodes, add the IP address CIDR ran
 
 You can do any of the following actions to the EKS Hybrid Nodes networking configuration in a cluster:
 
-* Add remote node network configuration to enable EKS Hybrid Nodes in an existing cluster.
-* Add, change, or remove the remote node networks.
-* Remove all remote node network CIDR ranges to disable EKS Hybrid Nodes in an existing cluster.
-* Add, change, or remove the optional remote pod networks. 
-* Remove all of remote pod network CIDR ranges.
-
-The following examples enable EKS Hybrid Nodes on an existing cluster and include the optional remote pod network.
+* <<hybrid-nodes-cluster-enable-existing,Add remote network configuration to enable EKS Hybrid Nodes in an existing cluster.>>
+* <<hybrid-nodes-cluster-update-config,Add, change, or remove the remote node networks or the remote pod networks in an existing cluster.>>
+* <<hybrid-nodes-cluster-disable,Remove all remote node network CIDR ranges to disable EKS Hybrid Nodes in an existing cluster.>>
 
 [#hybrid-nodes-cluster-enable-prep]
 == Prerequisites
 
-* The latest version of the {aws} Command Line Interface ({aws} CLI) installed and configured on your device. To check your current version, use `aws --version`. Package managers such yum, apt-get, or Homebrew for macOS are often several versions behind the latest version of the {aws} CLI. To install the latest version, see link:cli/latest/userguide/getting-started-install.html[Installing or updating to the last version of the {aws} CLI,type="documentation"] and link:cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config[Configuring settings for the {aws} CLI,type="documentation"] in the {aws} Command Line Interface User Guide.
+* The latest version of the {aws} Command Line Interface ({aws} CLI) installed and configured on your device. To check your current version, use `aws --version`. Package managers such yum, apt-get, or Homebrew for macOS are often several versions behind the latest version of the {aws} CLI. To install the latest version, see link:cli/latest/userguide/getting-started-install.html[Installing or updating to the latest version of the {aws} CLI,type="documentation"] and link:cli/latest/userguide/cli-configure-quickstart.html#cli-configure-quickstart-config[Configuring settings for the {aws} CLI,type="documentation"] in the {aws} Command Line Interface User Guide.
 * Before enabling your Amazon EKS cluster for hybrid nodes, ensure your environment meets the requirements outlined at <<hybrid-nodes-prereqs>>, and detailed at <<hybrid-nodes-networking>>, <<hybrid-nodes-os>>, and <<hybrid-nodes-creds>>.
 * Your cluster must use IPv4 address family.
 * Your cluster must use either API or API_AND_CONFIG_MAP for the cluster authentication mode. The process for modifying the cluster authentication mode is described at <<setting-up-access-entries>>.
@@ -129,3 +125,112 @@ aws eks describe-cluster \
 . Choose *Save changes* to finish. Wait for the cluster status to return to *Active*.
 
 . Continue to <<hybrid-nodes-cluster-prep>>.
+
+[#hybrid-nodes-cluster-update-config] 
+== Update hybrid nodes configuration in an existing cluster
+
+You can modify `remoteNetworkConfig` in an existing hybrid cluster using:
+
+* <<hybrid-nodes-cluster-update-cfn,{aws} CloudFormation>>
+* <<hybrid-nodes-cluster-update-cli,{aws} CLI>>
+* <<hybrid-nodes-cluster-update-console,{aws-management-console}>>
+
+[#hybrid-nodes-cluster-update-cfn] 
+=== Update hybrid configuration in an existing cluster - {aws} CloudFormation
+
+. Update your CloudFormation template with the new network CIDR values.
++
+[source,yaml,subs="verbatim,attributes"]
+----
+RemoteNetworkConfig:
+  RemoteNodeNetworks:
+    - Cidrs: [NEW_REMOTE_NODE_CIDRS]
+  RemotePodNetworks:
+    - Cidrs: [NEW_REMOTE_POD_CIDRS]
+----
+NOTE: When updating `RemoteNodeNetworks` or `RemotePodNetworks` CIDR lists, include all desired CIDRs (new and existing). EKS replaces the entire list during updates.
+Omitting these fields from the update request retains their existing configurations.
+
+. Update your CloudFormation stack with the modified template and wait for the stack update to complete.
+
+[#hybrid-nodes-cluster-update-cli] 
+=== Update hybrid configuration in an existing cluster - {aws} CLI
+
+. To modify the remote network CIDRs, run the following command. Replace the values with your desired settings:
++
+[source,bash,subs="verbatim,attributes"]
+----
+aws eks update-cluster
+--name CLUSTER_NAME
+--region AWS_REGION
+--remote-network-config '{"remoteNodeNetworks":[{"cidrs":["NEW_REMOTE_NODE_CIDRS"]}],"remotePodNetworks":[{"cidrs":["NEW_REMOTE_POD_CIDRS"]}]}'
+----
+NOTE: When updating `remoteNodeNetworks` or `remotePodNetworks` CIDR lists, include all desired CIDRs (new and existing). EKS replaces the entire list during updates.
+Omitting these fields from the update request retains their existing configurations.
+
+. Wait for the cluster status to return to ACTIVE before proceeding.
+
+[#hybrid-nodes-cluster-update-console] 
+=== Update hybrid configuration in an existing cluster - {aws-management-console}
+
+. Open the Amazon EKS console at link:eks/home#/clusters[Amazon EKS console,type="console"].
+. Choose the name of the cluster to display your cluster information.
+. Choose the *Networking* tab and choose *Manage*.
+. In the dropdown, choose *Remote networks*.
+. Update the CIDRs under `Remote node networks` and `Remote pod networks - Optional` as needed.
+. Choose *Save changes* and wait for the cluster status to return to *Active*.
+
+
+[#hybrid-nodes-cluster-disable]
+== Disable Hybrid nodes in an existing cluster
+
+You can disable EKS Hybrid Nodes in an existing cluster by using:
+
+* <<hybrid-nodes-cluster-disable-cfn,{aws} CloudFormation>>
+* <<hybrid-nodes-cluster-disable-cli,{aws} CLI>>
+* <<hybrid-nodes-cluster-disable-console,{aws-management-console}>>
+
+[#hybrid-nodes-cluster-disable-cfn]
+=== Disable EKS Hybrid Nodes in an existing cluster - {aws} CloudFormation
+
+. To disable EKS Hybrid Nodes in your cluster, set `RemoteNodeNetworks` and `RemotePodNetworks` to empty arrays in your CloudFormation template and update the stack.
++
+[source,yaml,subs="verbatim,attributes"]
+----
+RemoteNetworkConfig:
+  RemoteNodeNetworks: []
+  RemotePodNetworks: []
+----
+
+[#hybrid-nodes-cluster-disable-cli]
+=== Disable EKS Hybrid Nodes in an existing cluster - {aws} CLI
+. Run the following command to remove `RemoteNetworkConfig` from your EKS cluster. Before running the command, replace the following with your desired settings. For a full list of settings, see the link:eks/latest/APIReference/API_UpdateClusterConfig.html[UpdateClusterConfig,type="documentation"] in the _Amazon EKS API Reference_.
+.. `CLUSTER_NAME`: name of the EKS cluster to update.
+.. `AWS_REGION`: {aws} Region where the EKS cluster is running.
++
+[source,bash,subs="verbatim,attributes"]
+----
+aws eks update-cluster \
+    --name CLUSTER_NAME \
+    --region AWS_REGION \
+    --remote-network-config '{"remoteNodeNetworks":[],"remotePodNetworks":[]}' 
+----
+. It takes several minutes to update the cluster. You can query the status of your cluster with the following command. Replace `CLUSTER_NAME` with the name of the cluster you are modifying and `AWS_REGION` with the {aws} Region where the cluster is running. Don't proceed to the next step until the output returned is `ACTIVE`.
++
+[source,bash,subs="verbatim,attributes"]
+----
+aws eks describe-cluster \
+    --name CLUSTER_NAME \
+    --region AWS_REGION \
+    --query "cluster.status"
+----
+
+[#hybrid-nodes-cluster-disable-console]
+=== Disable EKS Hybrid Nodes in an existing cluster - {aws-management-console}
+
+. Open the Amazon EKS console at link:eks/home#/clusters[Amazon EKS console,type="console"].
+. Choose the name of the cluster to display your cluster information.
+. Choose the *Networking* tab and choose *Manage*.
+. In the dropdown, choose *Remote networks*.
+. Choose *Configure remote networks to enable hybrid nodes* and remove all the CIDRs under `Remote node networks` and `Remote pod networks - Optional`.
+. Choose *Save changes* to finish. Wait for the cluster status to return to *Active*.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds steps for modifying existing `remoteNetworkConfig` and removing it entirely from existing hybrid clusters.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
