### PR TITLE
fix: explicitily mention Gravtion in ARM docs

### DIFF
--- a/latest/ug/nodes/retrieve-ami-id.adoc
+++ b/latest/ug/nodes/retrieve-ami-id.adoc
@@ -18,7 +18,7 @@ You can retrieve the image ID of the latest recommended Amazon EKS optimized Ama
 * Replace [.replaceable]`ami-type` with one of the following options. For information about the types of Amazon EC2 instances, see link:AWSEC2/latest/UserGuide/instance-types.html[Amazon EC2 instance types,type="documentation"].
 +
 ** Use [.replaceable]`amazon-linux-2023/x86_64/standard` for Amazon Linux 2023 (AL2023) `x86` based instances.
-** Use [.replaceable]`amazon-linux-2023/arm64/standard` for AL2023 ARM instances.
+** Use [.replaceable]`amazon-linux-2023/arm64/standard` for AL2023 ARM instances, such as link:ec2/graviton/[{aws} Graviton,type="marketing"] based instances.
 ** Use [.replaceable]`amazon-linux-2023/x86_64/nvidia` for the latest approved AL2023 NVIDIA `x86` based instances.
 ** Use [.replaceable]`amazon-linux-2023/arm64/nvidia` for the latest approved AL2023 NVIDIA `arm64` based instances.
 ** Use [.replaceable]`amazon-linux-2023/x86_64/neuron` for the latest AL2023 link:machine-learning/neuron/[{aws} Neuron,type="marketing"] instances.


### PR DESCRIPTION
*Issue #, if available:*

n/a

*Description of changes:*

Explicitly mention Graviton in docs for `amazon-linux-2023/arm64/standard` to make it clearer that AL2023 supports Graviton

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
