### PR TITLE
Revert "document issues with R53 private hosted zones using .local do…

### DIFF
--- a/latest/ug/automode/auto-troubleshoot.adoc
+++ b/latest/ug/automode/auto-troubleshoot.adoc
@@ -262,14 +262,6 @@ securityContext:
     level: "s0:c123,c456,c789"
 ----
 
-
-[#auto-troubleshoot-local-suffix-name-resolution]
-== DNS Resolution of Route53 private hosted zones with `.local` Domains
-
-If you configure a Route 53 private hosted zone using a `.local` suffix (e.g. `mydomain.local`), it will fail to resolve on EKS Auto Mode Nodes. You will need to use a different suffix for the Route 53 private hosted zone.
-
-It's a general best practice to not use the domain name ".local" for Route 53 private hosted zones. RFC 6762 reserves this domain name for exclusive Multicast DNS use. For more information, see https://datatracker.ietf.org/doc/html/rfc6762[Multicast DNS] on the Internet Engineering Task Force (IETF) website. The use of this name interferes with DNS Resolution as it leads to attempting to resolve the name via Multicast DNS instead of forwarding the query to the VPC resolver endpoint.
-
 [#auto-troubleshoot-controllers]
 == Troubleshoot included controllers in Auto Mode
 


### PR DESCRIPTION
…mains (#952)"

This reverts commit 6c8026ab58e41400c0c91ae6423e39ddbb7aff77.

*Issue #, if available:*

*Description of changes:*

We shipped a [change](https://github.com/bottlerocket-os/bottlerocket-core-kit/pull/464) in Bottlerocket that is in the EKS Auto Mode AMI for this week that allows these domains to work for Auto Mode.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
