### PR TITLE
Minor update to EKS Auto nodeclass documentation

### DIFF
--- a/latest/ug/automode/create-node-class.adoc
+++ b/latest/ug/automode/create-node-class.adoc
@@ -107,7 +107,7 @@ For information about deploying CloudFormation stacks, see link:AWSCloudFormatio
 apiVersion: eks.amazonaws.com/v1
 kind: NodeClass
 metadata:
-  name: MyNodeClass
+  name: my-node-class
 spec:
   # Required fields
   role: MyNodeRole  # IAM role for EC2 instances


### PR DESCRIPTION
*Issue #, if available:* Fixed NodeClass naming convention to use lowercase characters. Changed 'MyNodeClass' to follow Kubernetes naming requirements which mandate lowercase RFC 1123 subdomain format. 

*Description of changes:* Changed the nodeclass name from 'MyNodeClass' to 'my-node-class'.

Error observed when used 'MyNodeClass' name :
[+] kubectl apply -f nodeclass.yaml            
The NodeClass "MyNodeClass" is invalid: metadata.name: Invalid value: "MyNodeClass": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
