### PR TITLE
Update access-policy-reference.adoc

### DIFF
--- a/latest/ug/manage-access/k8s-access/access-policy-reference.adoc
+++ b/latest/ug/manage-access/k8s-access/access-policy-reference.adoc
@@ -336,6 +336,11 @@ If you manually specifiy a Node IAM role in a NodeClass, you need to create an A
 
 == AmazonEKSBlockStoragePolicy
 
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
+
 *ARN* – `{arn-aws}eks::aws:cluster-access-policy/AmazonEKSBlockStoragePolicy`
 
 This policy includes permissions that allow Amazon EKS to manage leader election and coordination resources for storage operations:
@@ -376,6 +381,11 @@ Amazon EKS automatically creates an access entry with this access policy for the
 
 == AmazonEKSComputePolicy
 
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
+
 *ARN* – `{arn-aws}eks::aws:cluster-access-policy/AmazonEKSComputePolicy`
 
 This policy includes permissions that allow Amazon EKS to manage leader election resources for compute operations:
@@ -387,6 +397,11 @@ The policy is scoped specifically to compute management lease resources while al
 Amazon EKS automatically creates an access entry with this access policy for the cluster IAM role when Auto Mode is enabled, ensuring that the necessary permissions are in place for the networking capability to function properly.
 
 == AmazonEKSBlockStorageClusterPolicy
+
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
 
 *ARN* – `{arn-aws}eks::aws:cluster-access-policy/AmazonEKSBlockStorageClusterPolicy`
 
@@ -426,6 +441,11 @@ This policy is designed to support comprehensive block storage management within
 Amazon EKS automatically creates an access entry with this access policy for the cluster IAM role when Auto Mode is enabled, ensuring that the necessary permissions are in place for the block storage capability to function properly.
 
 == AmazonEKSComputeClusterPolicy
+
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
 
 *ARN* – `{arn-aws}eks::aws:cluster-access-policy/AmazonEKSComputeClusterPolicy`
 
@@ -534,6 +554,10 @@ Amazon EKS automatically creates an access entry with this access policy for the
 [#access-policy-permissions-amazonekshybridpolicy]
 == AmazonEKSHybridPolicy
 
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
 
 This access policy includes permissions that grant EKS access to the nodes of a cluster. When associated to an access entry, its access scope is typically the cluster, rather than a Kubernetes namespace. This policy is used by Amazon EKS hybrid nodes.
 
@@ -556,6 +580,11 @@ This access policy includes permissions that grant EKS access to the nodes of a 
 
 [[access-policy-permissions-AmazonEKSClusterInsightsPolicy,access-policy-permissions-AmazonEKSClusterInsightsPolicy.title]]
 == AmazonEKSClusterInsightsPolicy
+
+[NOTE]
+====
+This policy is designated for AWS service-linked roles only and cannot be used with customer-managed roles.
+====
 
 *ARN* – `{arn-aws}eks::aws:cluster-access-policy/AmazonEKSClusterInsightsPolicy`
 


### PR DESCRIPTION
Some of our access entry policies are SLR-only, meaning users can't associate them with an access entry. cc @DanielCKennedy

*Issue #, if available:*
N/A 

*Description of changes:*
The note in this PR makes it clear which policies are designated for AWS service-linked roles only (as of today):

- AmazonEKSClusterInsightsPolicy
- AmazonEKSHybridPolicy
- AmazonEKSComputeClusterPolicy
- AmazonEKSBlockStorageClusterPolicy
- AmazonEKSComputePolicy
- AmazonEKSBlockStoragePolicy

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
