### PR TITLE
Update lbc-helm.adoc

### DIFF
--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -109,7 +109,7 @@ helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
   -n kube-system \
   --set clusterName=my-cluster \
   --set serviceAccount.create=false \
-  --set serviceAccount.name=aws-load-balancer-controller
+  --set serviceAccount.name=aws-load-balancer-controller \
   --version 1.13.0
 ----
 


### PR DESCRIPTION
Added a backslash at the end of line 112

*Issue #, if available:*

*Description of changes:*
The helm installation command in pt.3 [here](https://docs.aws.amazon.com/eks/latest/userguide/lbc-helm.html#lbc-helm-install) is missing a backslash `\` after "--set serviceAccount.name=aws-load-balancer-controller" resulting in an error like "command not found: --version". Adding a backslash to avoid this issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
