### PR TITLE
Fix typo in version number

### DIFF
--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -110,7 +110,7 @@ helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
   --set clusterName=my-cluster \
   --set serviceAccount.create=false \
   --set serviceAccount.name=aws-load-balancer-controller \
-  --version 1.13.0
+  --version 2.13.0
 ----
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
helm install command had version number 1.13.0, but version number in other areas (and current release) is 2.13.0, an easy typo to make / miss.

Does this doc site have automation for current version number to keep this up to date?

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
