### PR TITLE
Update metrics-server.adoc

### DIFF
--- a/latest/ug/cluster-management/metrics-server.adoc
+++ b/latest/ug/cluster-management/metrics-server.adoc
@@ -20,7 +20,7 @@ The metrics are meant for point-in-time analysis and aren't an accurate source f
 
 == Considerations
 
-* The Amazon EKS add-on version of Metrics Server is pre-configured to use port `10251`, whereas a manually deployed Metrics Server using the manifest defaults to use port `10250`. If manually deploying Kubernetes Metrics Server onto Fargate nodes, configure the `metrics-server` deployment to use a port other than the `10250`, as this port is reserved for Fargate.
+* If manually deploying Kubernetes Metrics Server onto Fargate nodes using the manifest, configure the `metrics-server` deployment to use a port other than its default of `10250`. This port is reserved for Fargate. The Amazon EKS add-on version of Metrics Server is pre-configured to use port `10251`.
 * Ensure security groups and network ACLs allow port `10250` between the `metrics-server` Pods and all other nodes and Pods. The Kubernetes Metrics Server still uses port `10250` to collect metrics from other endpoints in the cluster. If you deploy on Fargate nodes, allow both the configured alternate Metrics Server port and port `10250`.
 
 == Deploy as community add-on with Amazon EKS Add-ons 

--- a/latest/ug/cluster-management/metrics-server.adoc
+++ b/latest/ug/cluster-management/metrics-server.adoc
@@ -20,8 +20,8 @@ The metrics are meant for point-in-time analysis and aren't an accurate source f
 
 == Considerations
 
-* If deploying Kubernetes Metrics Server onto Fargate nodes, the metric-server deployment must be reconfigured to use a different port other then the default of 10250. Port 10250 is reserved for Fargate. The Amazon EKS Add-on of the Metrics Server is already configured to use port 10251, so it is only if you are manually deploying using the manifest that it must be changed to something other than 10250.
-* Ensure port 10250 is allowed between the metrics-server pods and all other nodes/pods via Security Groups and Network ACLs. The Kuberentes Metrics Server solution still uses port 10250 to collect metrics from other endpoints in the cluster. If deploying Kubernetes Metrics Server onto Fargate nodes, ensure both the altered Metrics Server port and port 10250 are allowed.
+* The Amazon EKS add-on version of Metrics Server is pre-configured to use port `10251`, whereas a manually deployed Metrics Server using the manifest defaults to use port `10250`. If manually deploying Kubernetes Metrics Server onto Fargate nodes, configure the `metrics-server` deployment to use a port other than the `10250`, as this port is reserved for Fargate.
+* Ensure security groups and network ACLs allow port `10250` between the `metrics-server` Pods and all other nodes and Pods. The Kubernetes Metrics Server still uses port `10250` to collect metrics from other endpoints in the cluster. If you deploy on Fargate nodes, allow both the configured alternate Metrics Server port and port `10250`.
 
 == Deploy as community add-on with Amazon EKS Add-ons 
 

--- a/latest/ug/cluster-management/metrics-server.adoc
+++ b/latest/ug/cluster-management/metrics-server.adoc
@@ -18,6 +18,11 @@ The Kubernetes Metrics Server is an aggregator of resource usage data in your cl
 The metrics are meant for point-in-time analysis and aren't an accurate source for historical analysis. They can't be used as a monitoring solution or for other non-auto scaling purposes. For information about monitoring tools, see <<eks-observe>>.
 ====
 
+== Considerations
+
+* If deploying Kubernetes Metrics Server onto Fargate nodes, the metric-server deployment must be reconfigured to use a different port other then the default of 10250. Port 10250 is reserved for Fargate. The Amazon EKS Add-on of the Metrics Server is already configured to use port 10251, so it is only if you are manually deploying using the manifest that it must be changed to something other than 10250.
+* Ensure port 10250 is allowed between the metrics-server pods and all other nodes/pods via Security Groups and Network ACLs. The Kuberentes Metrics Server solution still uses port 10250 to collect metrics from other endpoints in the cluster. If deploying Kubernetes Metrics Server onto Fargate nodes, ensure both the altered Metrics Server port and port 10250 are allowed.
+
 == Deploy as community add-on with Amazon EKS Add-ons 
 
 *New: You can now deploy Metrics Server as a community add-on using the {aws} console or Amazon EKS APIs.*


### PR DESCRIPTION
It's common customers get confused on what ports Metrics Server uses, especially when deploying them on Fargate nodes. I added a Considerations section to try and help clarify what to do when deploying Metrics Server on Fargate Nodes and what ports need to be allowed via Security Groups and Network ACLs for the Metrics Server to work.

*Issue #, if available:* N/A

*Description of changes:*
Added a **Considerations** section to clarify what to consider when deploy the k8s Metrics Server solution onto Fargate nodes and what ports need to be allowed for this solution to work.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
