### PR TITLE
Add Private CA Addon

### DIFF
--- a/latest/ug/workloads/workloads-add-ons-available-eks.adoc
+++ b/latest/ug/workloads/workloads-add-ons-available-eks.adoc
@@ -78,6 +78,10 @@ You can use any of the following Amazon EKS add-ons.
 |<<add-ons-pod-id>>
 |EC2, EKS Hybrid Nodes
 
+|Enable users to obtain certificates from AWS Private Certificate Authority (AWS Private CA) for Kubernetes
+|<<add-ons-aws-privateca-connector>>
+|EC2, EKS Auto Mode
+
 |===
 
 [#add-ons-vpc-cni]
@@ -482,6 +486,29 @@ eksctl create iamserviceaccount \
 === Additional information
 
 For more information, see link:AmazonCloudWatch/latest/monitoring/install-CloudWatch-Observability-EKS-addon.html[Install the CloudWatch agent,type="documentation"].
+
+[#add-ons-aws-privateca-connector]
+== AWS Private CA Connector for Kubernetes
+
+[abstract]
+--
+Learn about the AWS Private CA Connector for Kubernetes Amazon EKS add-on.
+--
+
+The AWS Private CA Connector for Kubernetes is an add-on for cert-manager that enables users to obtain Certificates from AWS Private Certificate Authority (AWS Private CA).
+
+* The Amazon EKS add-on name is `aws-privateca-connector-for-kubernetes`.
+* The add-on namespace is `aws-privateca-issuer`.
+
+[#add-ons-aws-privateca-connector-iam-permissions]
+=== Required IAM permissions
+
+This add-on uses the IAM roles for service accounts capability of Amazon EKS. For more information, see <<iam-roles-for-service-accounts>>.
+
+[#add-ons-aws-privateca-connector-information]
+=== Additional information
+
+For more information, see the https://github.com/cert-manager/aws-privateca-issuer[AWS Private CA Issuer for Kubernetes GitHub repository].
 
 [#add-ons-pod-id]
 == EKS Pod Identity Agent

--- a/latest/ug/workloads/workloads-add-ons-available-eks.adoc
+++ b/latest/ug/workloads/workloads-add-ons-available-eks.adoc
@@ -78,9 +78,9 @@ You can use any of the following Amazon EKS add-ons.
 |<<add-ons-pod-id>>
 |EC2, EKS Hybrid Nodes
 
-|Enable users to obtain certificates from AWS Private Certificate Authority (AWS Private CA) for Kubernetes
+|Enable cert-manager to issue X.509 certificates from AWS Private CA. Requires cert-manager.
 |<<add-ons-aws-privateca-connector>>
-|EC2, EKS Auto Mode
+|EC2, Fargate, EKS Auto Mode, EKS Hybrid Nodes
 
 |===
 
@@ -503,7 +503,13 @@ The AWS Private CA Connector for Kubernetes is an add-on for cert-manager that e
 [#add-ons-aws-privateca-connector-iam-permissions]
 === Required IAM permissions
 
-This add-on uses the IAM roles for service accounts capability of Amazon EKS. For more information, see <<iam-roles-for-service-accounts>>.
+This add-on requires IAM permissions.
+
+Use EKS Pod Identities to attach the `AWSPrivateCAConnectorForKubernetesPolicy` IAM Policy to the `aws-privateca-issuer` Kubernetes Service Account. 
+
+For more information, see <<update-addon-role>>.
+
+For information about the required permissions, see link:aws-managed-policy/latest/reference/AWSPrivateCAConnectorForKubernetesPolicy.html[AWSPrivateCAConnectorForKubernetesPolicy,type="documentation"] in the {aws} Managed Policy Reference. 
 
 [#add-ons-aws-privateca-connector-information]
 === Additional information
@@ -530,15 +536,10 @@ The Amazon EKS add-on name is `eks-pod-identity-agent`.
 [#add-ons-pod-id-iam-permissions]
 === Required IAM permissions
 
-This add-on requires IAM permissions.
-
-Use EKS Pod Identities to attach the `AWSPrivateCAConnectorForKubernetesPolicy` IAM Policy to the `aws-privateca-issuer` Kubernetes Service Account. 
-
-For more information, see <<update-addon-role>>.
-
-For information about the required permissions, see link:aws-managed-policy/latest/reference/AWSPrivateCAConnectorForKubernetesPolicy.html[AWSPrivateCAConnectorForKubernetesPolicy,type="documentation"] in the {aws} Managed Policy Reference. 
+This add-on users permissions from the <<create-node-role,Amazon EKS node IAM role>>.
 
 [#add-ons-pod-id-update-information]
 === Update information
 
 You can only update one minor version at a time. For example, if your current version is `1.28.x-eksbuild.y` and you want to update to `1.30.x-eksbuild.y`, then you must update your current version to `1.29.x-eksbuild.y` and then update it again to `1.30.x-eksbuild.y`. For more information about updating the add-on, see <<vpc-add-on-update>>.
+

--- a/latest/ug/workloads/workloads-add-ons-available-eks.adoc
+++ b/latest/ug/workloads/workloads-add-ons-available-eks.adoc
@@ -530,7 +530,13 @@ The Amazon EKS add-on name is `eks-pod-identity-agent`.
 [#add-ons-pod-id-iam-permissions]
 === Required IAM permissions
 
-This add-on users permissions from the <<create-node-role,Amazon EKS node IAM role>>.
+This add-on requires IAM permissions.
+
+Use EKS Pod Identities to attach the `AWSPrivateCAConnectorForKubernetesPolicy` IAM Policy to the `aws-privateca-issuer` Kubernetes Service Account. 
+
+For more information, see <<update-addon-role>>.
+
+For information about the required permissions, see link:aws-managed-policy/latest/reference/AWSPrivateCAConnectorForKubernetesPolicy.html[AWSPrivateCAConnectorForKubernetesPolicy,type="documentation"] in the {aws} Managed Policy Reference. 
 
 [#add-ons-pod-id-update-information]
 === Update information

--- a/latest/ug/workloads/workloads-add-ons-available-eks.adoc
+++ b/latest/ug/workloads/workloads-add-ons-available-eks.adoc
@@ -516,6 +516,10 @@ For information about the required permissions, see link:aws-managed-policy/late
 
 For more information, see the https://github.com/cert-manager/aws-privateca-issuer[AWS Private CA Issuer for Kubernetes GitHub repository].
 
+For more information about configuring the add-on, see https://github.com/cert-manager/aws-privateca-issuer/blob/main/charts/aws-pca-issuer/values.yaml[values.yaml] in the `aws-privateca-issuer` GitHub repo. Confirm the version of values.yaml matches the version of the add-on installed on your cluster. 
+
+This add-on tolerates the `CriticalAddonsOnly` taint used by the `system` NodePool of EKS Auto Mode. For more information, see <<critical-workload>>. 
+
 [#add-ons-pod-id]
 == EKS Pod Identity Agent
 


### PR DESCRIPTION
This PR introduces a new AWS Private CA Connector add-on for Kubernetes documentation to be used with Amazon EKS. The changes include adding an entry to the add-ons table and a dedicated section detailing the add-on's purpose, usage, and IAM permissions.