### PR TITLE
Fixed Header Bolding in network-policies-troubleshooting

### DIFF
--- a/latest/ug/networking/network-policies-troubleshooting.adoc
+++ b/latest/ug/networking/network-policies-troubleshooting.adoc
@@ -185,7 +185,7 @@ The following screenshot shows an example of this scenario.
 image::images/console-cni-config-network-policy-logs-cwl.png[{aws-management-console} showing the VPC CNI add-on with network policy and CloudWatch Logs in the optional configuration.,scaledwidth=80%]
 
 
-{aws} CLI::
+*{aws} CLI*::
 .. Run the following {aws} CLI command. Replace `my-cluster` with the name of your cluster and replace the IAM role ARN with the role that you are using.
 +
 [source,shell,subs="verbatim,attributes"]
@@ -199,7 +199,7 @@ aws eks update-addon --cluster-name my-cluster --addon-name vpc-cni --addon-vers
 [#cni-network-policy-cwl-agent-selfmanaged]
 ==== Self-managed add-on
 
-Helm::
+*Helm*::
 
 If you have installed the Amazon VPC CNI plugin for Kubernetes through `helm`, you can update the configuration to send network policy logs to CloudWatch Logs.
 
@@ -211,7 +211,7 @@ helm upgrade --set nodeAgent.enablePolicyEventLogs=true --set nodeAgent.enableCl
 ----
 
 
-kubectl::
+*kubectl*::
 .. Open the `aws-node` `DaemonSet` in your editor.
 +
 [source,bash,subs="verbatim,attributes"]


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:* Formatting

In https://docs.aws.amazon.com/eks/latest/userguide/network-policies-troubleshooting.html:

The Headers AWS CLI, Helm and kubectl were not bold and do not match the AWS Management Console Header seen above these


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
