### PR TITLE
Update sample-deployment-windows.adoc

### DIFF
--- a/latest/ug/workloads/sample-deployment-windows.adoc
+++ b/latest/ug/workloads/sample-deployment-windows.adoc
@@ -58,7 +58,7 @@ spec:
           requiredDuringSchedulingIgnoredDuringExecution:
             nodeSelectorTerms:
             - matchExpressions:
-              - key: beta.kubernetes.io/arch
+              - key: kubernetes.io/arch
                 operator: In
                 values:
                 - amd64


### PR DESCRIPTION
*Description of changes:*

spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key: beta.kubernetes.io/arch is deprecated since v1.14; use "kubernetes.io/arch" instead

Updated sample to use "kubernetes.io/arch" instead


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
