### PR TITLE
Fix: Update messaging on MNG and Fargate profiles for cluster access

### DIFF
--- a/latest/ug/manage-access/k8s-access/migrating-access-entries.adoc
+++ b/latest/ug/manage-access/k8s-access/migrating-access-entries.adoc
@@ -12,7 +12,7 @@ If you've added entries to the `aws-auth` `ConfigMap` on your cluster, we recomm
 [IMPORTANT]
 ====
 
-Before removing existing `aws-auth` `ConfigMap` entries that were created by Amazon EKS for <<managed-node-groups,managed node group>> or a <<fargate-profile,Fargate profile>> to your cluster, double check if the correct Access Entries for those specific resources exist in your Amazon EKS cluster. If you remove entries that Amazon EKS created in the `ConfigMap`, without having the equivalent Access Entries, your cluster won't function properly. 
+Before removing existing `aws-auth` `ConfigMap` entries that were created by Amazon EKS for <<managed-node-groups,managed node group>> or a <<fargate-profile,Fargate profile>> to your cluster, double check if the correct access entries for those specific resources exist in your Amazon EKS cluster. If you remove entries that Amazon EKS created in the `ConfigMap` without having the equivalent access entries, your cluster won't function properly.
 
 ====
 

--- a/latest/ug/manage-access/k8s-access/migrating-access-entries.adoc
+++ b/latest/ug/manage-access/k8s-access/migrating-access-entries.adoc
@@ -12,7 +12,7 @@ If you've added entries to the `aws-auth` `ConfigMap` on your cluster, we recomm
 [IMPORTANT]
 ====
 
-Don't remove existing `aws-auth` `ConfigMap` entries that were created by Amazon EKS when you added a <<managed-node-groups,managed node group>> or a <<fargate-profile,Fargate profile>> to your cluster. If you remove entries that Amazon EKS created in the `ConfigMap`, your cluster won't function properly. You can however, remove any entries for <<worker,self-managed>> node groups after you've created access entries for them.
+Before removing existing `aws-auth` `ConfigMap` entries that were created by Amazon EKS for <<managed-node-groups,managed node group>> or a <<fargate-profile,Fargate profile>> to your cluster, double check if the correct Access Entries for those specific resources exist in your Amazon EKS cluster. If you remove entries that Amazon EKS created in the `ConfigMap`, without having the equivalent Access Entries, your cluster won't function properly. 
 
 ====
 


### PR DESCRIPTION
*Issue #, if available:*

Fixes: #1038 

*Description of changes:*

Update the messaging that ask customers to avoid removing entries related to Managed Node Groups and Fargate Profiles from the `aws-auth` `configMap`. The entries are safe to be removed if there are equivalent EKS Access Entries in the cluter.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
