### PR TITLE
No need for Service type NodePort in Step 3

### DIFF
--- a/latest/ug/automode/auto-elb-example.adoc
+++ b/latest/ug/automode/auto-elb-example.adoc
@@ -102,7 +102,6 @@ spec:
     - port: 80
       targetPort: 80
       protocol: TCP
-  type: NodePort
   selector:
     app.kubernetes.io/name: app-2048
 ----


### PR DESCRIPTION
*Issue #, if available:* None.

*Description of changes:* Removed type : NodePort in Step 3. There is no need to configure the Service type as NodePort. In Ingress manifest target type IP is used hence the traffic will be sent directly to the Pod IP. Hence NodePort is unnecessary. Service type ClusterIP is enough. This is a reoccurring misleading  guidance which I requested to be corrected in AWS blogs as well.



By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
