### PR TITLE
Fix documentation: Remove invalid --approve flag from eksctl create podidentityassociation command

### DIFF
--- a/latest/ug/storage/efs-csi.adoc
+++ b/latest/ug/storage/efs-csi.adoc
@@ -74,8 +74,7 @@ eksctl create podidentityassociation \
     --namespace kube-system \
     --cluster $cluster_name \
     --role-name $role_name \
-    --permission-policy-arns {arn-aws}iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy \
-    --approve
+    --permission-policy-arns {arn-aws}iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
 ----
 
 [#efs-eksctl-irsa]


### PR DESCRIPTION
*Description*

This PR fixes a documentation issue where the `eksctl create podidentityassociation` command incorrectly includes an `--approve` flag that is not supported by this command. When running the command as shown in the documentation, users encounter an error:
```
Error: unknown flag: --approve
```
This PR removes the invalid flag from the command example. 

*Issue #, if available:*
Fixes #1048

*Description of changes:*
Removed the `--approve` flag from the `eksctl create podidentityassociation` command example in the [EFS CSI driver documentation](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html). 

Testing Done Verified that the `--approve` flag is not a valid option for the `eksctl create podidentityassociation` command by checking the command's help output.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
