### PR TITLE
Update kubernetes-versions-extended.adoc

### DIFF
--- a/latest/ug/clusters/kubernetes-versions-extended.adoc
+++ b/latest/ug/clusters/kubernetes-versions-extended.adoc
@@ -77,19 +77,3 @@ kubectl get pods --all-namespaces -o json | grep -E 'seccomp.security.alpha.kube
 
 For the complete Kubernetes `1.27` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1260.
 
-[#kubernetes-1-26]
-== Kubernetes 1.26
-
-Kubernetes `1.26` is now available in Amazon EKS. For more information about Kubernetes `1.26`, see the https://kubernetes.io/blog/2022/12/09/kubernetes-v1-26-release/[official release announcement].
-
-[IMPORTANT]
-====
-
-Kubernetes `1.26` no longer supports CRI `v1alpha2`. This results in the `kubelet` no longer registering the node if the container runtime doesn't support CRI `v1`. This also means that Kubernetes `1.26` doesn't support containerd minor version `1.5` and earlier. If you're using containerd, you need to upgrade to containerd version `1.6.0` or later before you upgrade any nodes to Kubernetes `1.26`. You also need to upgrade any other container runtimes that only support the `v1alpha2`. For more information, defer to the container runtime vendor. By default, Amazon Linux and Bottlerocket AMIs include containerd version `1.6.6`.
-
-====
-
-* Before you upgrade to Kubernetes `1.26`, upgrade your Amazon VPC CNI plugin for Kubernetes to version `1.12` or later. If you don't upgrade to Amazon VPC CNI plugin for Kubernetes version `1.12` or later, the Amazon VPC CNI plugin for Kubernetes will crash. For more information, see <<managing-vpc-cni>>.
-* The https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/[goaway-chance] option in the Kubernetes API server helps prevent `HTTP/2` client connections from being stuck on a single API server instance, by randomly closing a connection. When the connection is closed, the client will try to reconnect, and will likely land on a different API server as a result of load balancing. Amazon EKS version `1.26` has enabled `goaway-chance` flag. If your workload running on Amazon EKS cluster uses a client that is not compatible with https://www.rfc-editor.org/rfc/rfc7540#section-6.8[HTTP GOAWAY], we recommend that you update your client to handle `GOAWAY` by reconnecting on connection termination.
-
-For the complete Kubernetes `1.26` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md#changelog-since-v1250.


### PR DESCRIPTION
Removing reference to k8s version 1.26

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
