### PR TITLE
Update service-accounts.adoc

### DIFF
--- a/latest/ug/manage-access/aws-access/service-accounts.adoc
+++ b/latest/ug/manage-access/aws-access/service-accounts.adoc
@@ -92,7 +92,7 @@ At a high level, both EKS Pod Identity and IRSA enables you to grant IAM permiss
 
 [NOTE]
 ====
-AWS recommends using EKS Pod Identities to grant access to AWS resources to your pods whenever possible.
+{aws} recommends using EKS Pod Identities to grant access to {aws} resources to your pods whenever possible. For more information, see <<pod-identities>>. 
 ====
 
 [%header,cols="3"]
@@ -115,8 +115,8 @@ AWS recommends using EKS Pod Identities to grant access to AWS resources to your
 |In IRSA, you define the trust relationship between an IAM role and service account in the role's trust policy. By default, the length of trust policy size is `2048`. This means that you can typically define 4 trust relationships in a single trust policy. While you can get the trust policy length limit increased, you are typically limited to a max of 8 trust relationships within a single trust policy.
 
 |STS API Quota Usage
-|EKS Pod Identity simplifies delivery of AWS credentials to your pods, and does not require your code make calls with the AWS Security Token Service (STS) directly. The EKS service handles role assumption, and delivers credentials to applications written using the AWS SDK in your pods without your pods communicating with AWS STS or using STS API Quota.
-|In IRSA, applications written using the AWS SDK in your pods use tokens to call the `AssumeRoleWithWebIdentity` API on the AWS Security Token Service (STS). Depending on the logic of your code on the AWS SDK, it is possible for your code to make unneccesarry calls to AWS STS and receive throttling errors.
+|EKS Pod Identity simplifies delivery of {aws} credentials to your pods, and does not require your code make calls with the {aws} Security Token Service (STS) directly. The EKS service handles role assumption, and delivers credentials to applications written using the {aws} SDK in your pods without your pods communicating with {aws} STS or using STS API Quota.
+|In IRSA, applications written using the {aws} SDK in your pods use tokens to call the `AssumeRoleWithWebIdentity` API on the {aws} Security Token Service (STS). Depending on the logic of your code on the {aws} SDK, it is possible for your code to make unneccesarry calls to {aws} STS and receive throttling errors.
 
 |Role reusability
 |{aws} STS temporary credentials supplied by EKS Pod Identity include role session tags, such as cluster name, namespace, service account name. Role session tags enable administrators to author a single IAM role that can be used with multiple service accounts, with different effective permission, by allowing access to {aws} resources based on tags attached to them. This is also called attribute-based access control (ABAC). For more information, see <<pod-id-abac>>.

--- a/latest/ug/manage-access/aws-access/service-accounts.adoc
+++ b/latest/ug/manage-access/aws-access/service-accounts.adoc
@@ -90,6 +90,11 @@ EKS Pod Identity offers cluster administrators a simplified workflow for authent
 
 At a high level, both EKS Pod Identity and IRSA enables you to grant IAM permissions to applications running on Kubernetes clusters. But they are fundamentally different in how you configure them, the limits supported, and features enabled. Below, we compare some of the key facets of both solutions.
 
+[NOTE]
+====
+AWS recommends using EKS Pod Identities to grant access to AWS resources to your pods whenever possible.
+====
+
 [%header,cols="3"]
 |===
 |Attribute
@@ -108,6 +113,10 @@ At a high level, both EKS Pod Identity and IRSA enables you to grant IAM permiss
 |Role scalability
 |EKS Pod Identity doesn't require users to define trust relationship between IAM role and service account in the trust policy, so this limit doesn't apply.
 |In IRSA, you define the trust relationship between an IAM role and service account in the role's trust policy. By default, the length of trust policy size is `2048`. This means that you can typically define 4 trust relationships in a single trust policy. While you can get the trust policy length limit increased, you are typically limited to a max of 8 trust relationships within a single trust policy.
+
+|STS API Quota Usage
+|EKS Pod Identity simplifies delivery of AWS credentials to your pods, and does not require your code make calls with the AWS Security Token Service (STS) directly. The EKS service handles role assumption, and delivers credentials to applications written using the AWS SDK in your pods without your pods communicating with AWS STS or using STS API Quota.
+|In IRSA, applications written using the AWS SDK in your pods use tokens to call the `AssumeRoleWithWebIdentity` API on the AWS Security Token Service (STS). Depending on the logic of your code on the AWS SDK, it is possible for your code to make unneccesarry calls to AWS STS and receive throttling errors.
 
 |Role reusability
 |{aws} STS temporary credentials supplied by EKS Pod Identity include role session tags, such as cluster name, namespace, service account name. Role session tags enable administrators to author a single IAM role that can be used with multiple service accounts, with different effective permission, by allowing access to {aws} resources based on tags attached to them. This is also called attribute-based access control (ABAC). For more information, see <<pod-id-abac>>.


### PR DESCRIPTION
guidance on using pod identities, STS throttling

*Issue #, if available:*
N/A Slack me.

*Description of changes:*
IRSA has a very sharp edge that lets customers get themselves throttled by STS a lot. It's time we get more opinionated about using Pod identity over IRSA, and tell customers about this in the comparison table.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
