### PR TITLE
NIT: Typo in step 4 of security-groups-pods-deployment

### DIFF
--- a/latest/ug/networking/security-groups-pods-deployment.adoc
+++ b/latest/ug/networking/security-groups-pods-deployment.adoc
@@ -61,7 +61,6 @@ If you are using VPC CNI versions older than `1.15`, node labels were used inste
 [source,bash,subs="verbatim,attributes"]
 ----
 kubectl get nodes -o wide -l vpc.amazonaws.com/has-trunk-attached=true
--
 ----
 +
 Once the trunk network interface is created, Pods are assigned secondary IP addresses from the trunk or standard network interfaces. The trunk interface is automatically deleted if the node is deleted.


### PR DESCRIPTION
See step 4 in https://docs.aws.amazon.com/eks/latest/userguide/security-groups-pods-deployment.html

There is a `-` where it doesnt belong

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
