### PR TITLE
Add podSecurityGroupSelectorTerms to the NodeClass schema

### DIFF
--- a/latest/ug/automode/create-node-class.adoc
+++ b/latest/ug/automode/create-node-class.adoc
@@ -140,7 +140,12 @@ spec:
         kubernetes.io/role/pod: "1"
     # Alternative using direct subnet ID
     # - id: "subnet-0987654321fedcba0"
-
+# must include pod security group selector also
+ podSecurityGroupSelectorTerms:
+  - tags:
+      Name: "eks-pod-sg"
+    # Alternative using direct security group ID
+    # - id: "sg-0123456789abcdef0"
 
   # Optional: Selects on-demand capacity reservations and capacity blocks
   # for EKS Auto Mode to prioritize.


### PR DESCRIPTION
Add podSecurityGroupSelectorTerms to the schema for NodeClass for Auto Mode.

*Issue #, if available:*

*Description of changes:*

Copy the example `podSecurityGroupSelectorTerms` into the schema for NodeClass, this is required with the podSubnetSelectorTerms.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
