### PR TITLE
Update automode-learn-instances.adoc

### DIFF
--- a/latest/ug/automode/automode-learn-instances.adoc
+++ b/latest/ug/automode/automode-learn-instances.adoc
@@ -125,6 +125,9 @@ For more information about the Amazon EC2 Instance Metadata Service (IMDS), see 
 * If the configured ephemeral storage in the NodeClass is smaller than the NVMe local storage for the instance, EKS Auto Mode eliminates the need for manual configuration by automatically taking the following actions:
 ** Uses a smaller (20 GiB) Amazon EBS data volume to reduce costs.
 ** Formats and configures the NVMe local storage for ephemeral data use. This includes setting up a RAID 0 array if there are multiple NVMe drives.
+* When ephemeralStorage.size equals or exceeds the local NVMe capacity:
+** Auto Mode skips the small EBS volume.
+** The NVMe drive(s) are exposed directly for your workload.
 * Amazon EKS Auto Mode does not support {aws} Fault Injection Service. For more information, see link:resilience-hub/latest/userguide/testing.html["Managing Fault Injection Service experiments",type="documentation"] in the {aws} Resilience Hub User Guide. 
 * You do not need to install the `Neuron Device Plugin` on EKS Auto Mode nodes.
 +

--- a/latest/ug/automode/automode-learn-instances.adoc
+++ b/latest/ug/automode/automode-learn-instances.adoc
@@ -119,13 +119,12 @@ For more information, see link:ec2/latest/instancetypes/instance-type-names.html
 
 For more information about the Amazon EC2 Instance Metadata Service (IMDS), see link:AWSEC2/latest/UserGuide/configuring-instance-metadata-options.html[Configure the Instance Metadata Service options,type="documentation"] in the _Amazon EC2 User Guide_.
 
-
 == Considerations
 
 * If the configured ephemeral storage in the NodeClass is smaller than the NVMe local storage for the instance, EKS Auto Mode eliminates the need for manual configuration by automatically taking the following actions:
 ** Uses a smaller (20 GiB) Amazon EBS data volume to reduce costs.
 ** Formats and configures the NVMe local storage for ephemeral data use. This includes setting up a RAID 0 array if there are multiple NVMe drives.
-* When ephemeralStorage.size equals or exceeds the local NVMe capacity:
+* When `ephemeralStorage.size` equals or exceeds the local NVMe capacity, the following actions occur:
 ** Auto Mode skips the small EBS volume.
 ** The NVMe drive(s) are exposed directly for your workload.
 * Amazon EKS Auto Mode does not support {aws} Fault Injection Service. For more information, see link:resilience-hub/latest/userguide/testing.html["Managing Fault Injection Service experiments",type="documentation"] in the {aws} Resilience Hub User Guide. 


### PR DESCRIPTION
Providing additional details regarding the Auto Mode’s logic when the ephemeralStorage.size is equal to or exceeds the local NVMe capacity.

*Issue #, if available:* The current information lacks clarity regarding the utilization of local NVMe capacity instead of the 20 GB allocated. 

*Description of changes:* The provided information elucidates the manner in which you can utilize the local NVMe capacity by ensuring that the ephemeralStorage.size is equal to or exceeds it.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
