### PR TITLE
Removed 1.30 from standard support

### DIFF
--- a/latest/ug/versioning/kubernetes-versions.adoc
+++ b/latest/ug/versioning/kubernetes-versions.adoc
@@ -32,7 +32,6 @@ The following Kubernetes versions are currently available in Amazon EKS standard
 * `1.33`
 * `1.32`
 * `1.31`
-* `1.30`
 
 
 For important changes to be aware of for each version in standard support, see link:eks/latest/userguide/kubernetes-versions-standard.html[Kubernetes versions standard support,type="documentation"].


### PR DESCRIPTION
*Issue #, if available:*


*Description of changes:*

Updating the documentation to remove EKS `1.30` from standard support as it  expired on `July 23, 2025`.

https://github.com/awsdocs/amazon-eks-user-guide/blob/mainline/latest/ug/versioning/kubernetes-versions.adoc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
