### PR TITLE
Removed 1.27 and added 1.30 to Extended Support

### DIFF
--- a/latest/ug/versioning/kubernetes-versions.adoc
+++ b/latest/ug/versioning/kubernetes-versions.adoc
@@ -32,7 +32,6 @@ The following Kubernetes versions are currently available in Amazon EKS standard
 * `1.33`
 * `1.32`
 * `1.31`
-* `1.30`
 
 
 For important changes to be aware of for each version in standard support, see link:eks/latest/userguide/kubernetes-versions-standard.html[Kubernetes versions standard support,type="documentation"].

--- a/latest/ug/versioning/kubernetes-versions.adoc
+++ b/latest/ug/versioning/kubernetes-versions.adoc
@@ -41,9 +41,9 @@ For important changes to be aware of for each version in standard support, see l
 
 The following Kubernetes versions are currently available in Amazon EKS extended support:
 
+* `1.30`
 * `1.29`
 * `1.28`
-* `1.27`
 
 For important changes to be aware of for each version in extended support, see link:eks/latest/userguide/kubernetes-versions-extended.html[Kubernetes versions extended support,type="documentation"].
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating the documentation to remove EKS `1.27`  from extended support as it expired on `July 24, 2025` and added `1.30` to extended support.

https://github.com/awsdocs/amazon-eks-user-guide/blob/mainline/latest/ug/versioning/kubernetes-versions.adoc

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.