### PR TITLE
Update cni-custom-network-tutorial.adoc

### DIFF
--- a/latest/ug/networking/cni-custom-network-tutorial.adoc
+++ b/latest/ug/networking/cni-custom-network-tutorial.adoc
@@ -115,7 +115,7 @@ aws iam attach-role-policy --policy-arn {arn-aws}iam::aws:policy/AmazonEKSCluste
 ----
 aws eks create-cluster --name my-custom-networking-cluster \
    --role-arn {arn-aws}iam::$account_id:role/myCustomNetworkingAmazonEKSClusterRole \
-   --resources-vpc-config subnetIds=$subnet_id_1","$subnet_id_2
+   --resources-vpc-config subnetIds="$subnet_id_1","$subnet_id_2"
 ----
 +
 NOTE: You might receive an error that one of the Availability Zones in your request doesn't have sufficient capacity to create an Amazon EKS cluster. If this happens, the error output contains the Availability Zones that can support a new cluster. Retry creating your cluster with at least two subnets that are located in the supported Availability Zones for your account. For more information, see <<ice>>.


### PR DESCRIPTION
The aws eks create-cluster command was incorrect. The value in --resources-vpc-config subnetIds= argument had incorrect double quotations.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
