### PR TITLE
document the fix related to pod identity agent

### DIFF
--- a/latest/ug/automode/auto-change.adoc
+++ b/latest/ug/automode/auto-change.adoc
@@ -14,6 +14,10 @@ To receive notifications of all source file changes to this specific documentati
 https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/automode/auto-change.adoc.atom
 ----
 
+== August 15, 2025
+
+*Bug Fix:* The Pod Identity Agent will now only listen on the IPv4 Link Local address in an IPv4 EKS cluster to avoid issues where the Pod can't reach the IPv6 address.
+
 == August 6, 2025
 
 *Feature:* Added new configuration on the NodeClass `spec.advancedNetworking.associatePublicIPAddress` which can be used to prevent public IP addresses from being assigned to EKS Auto Mode Nodes


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The Pod Identity Agent will now only listen on the IPv4 Link Local address in an IPv4 EKS cluster to avoid issues where Pod can't reach the IPv6 address.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
