### PR TITLE
Updates EKS versioning documentation

### DIFF
--- a/latest/ug/versioning/kubernetes-versions-extended.adoc
+++ b/latest/ug/versioning/kubernetes-versions-extended.adoc
@@ -14,6 +14,27 @@ Amazon EKS supports Kubernetes versions longer than they are supported upstream,
 
 This topic gives important changes to be aware of for each [.noloc]`Kubernetes` version in extended support. When upgrading, carefully review the changes that have occurred between the old and new versions for your cluster.
 
+[#kubernetes-1-30]
+== Kubernetes 1.30
+
+Kubernetes `1.30` is now available in Amazon EKS. For more information about Kubernetes `1.30`, see the https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/[official release announcement].
+
+[IMPORTANT]
+====
+
+
+* Starting with Amazon EKS version `1.30` or newer, any newly created managed node groups will automatically default to using Amazon Linux 2023 (AL2023) as the node operating system. Previously, new node groups would default to Amazon Linux 2 (AL2). You can continue to use AL2 by choosing it as the AMI type when creating a new node group. 
+** For information about migrating from AL2 to AL2023, see <<al2023>>.
+** For more information about Amazon Linux, see link:linux/al2023/ug/compare-with-al2.html[Comparing AL2 and AL2023,type="documentation"] in the Amazon Linux User Guide. 
+** For more information about specifiying the operating system for a managed node group, see <<create-managed-node-group>>.
+
+====
+
+* With Amazon EKS `1.30`, the `topology.k8s.aws/zone-id` label is added to worker nodes. You can use Availability Zone IDs (AZ IDs) to determine the location of resources in one account relative to the resources in another account. For more information, see link:ram/latest/userguide/working-with-az-ids.html[Availability Zone IDs for your {aws} resources,type="documentation"] in the _{aws} RAM User Guide_. 
+* Starting with `1.30`, Amazon EKS no longer includes the `default` annotation on the `gp2 StorageClass` resource applied to newly created clusters. This has no impact if you are referencing this storage class by name. You must take action if you were relying on having a default `StorageClass` in the cluster. You should reference the `StorageClass` by the name `gp2`. Alternatively, you can deploy the Amazon EBS recommended default storage class by setting the `defaultStorageClass.enabled` parameter to true when installing version `1.31.0` or later of the `aws-ebs-csi-driver add-on`. 
+* The minimum required IAM policy for the Amazon EKS cluster IAM role has changed. The action `ec2:DescribeAvailabilityZones` is required. For more information, see <<cluster-iam-role>>.
+
+For the complete Kubernetes `1.30` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md.
 
 [#kubernetes-1-29]
 == Kubernetes 1.29
@@ -50,30 +71,3 @@ Kubernetes `1.28` is now available in Amazon EKS. For more information about Kub
 * The `PersistentVolume (PV)` controller has been modified to automatically assign a default `StorageClass` to any unbound `PersistentVolumeClaim` with the `storageClassName` not set. Additionally, the `PersistentVolumeClaim` admission validation mechanism within the API server has been adjusted to allow changing values from an unset state to an actual `StorageClass` name.
 
 For the complete Kubernetes `1.28` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.28.md#changelog-since-v1270.
-
-[#kubernetes-1-27]
-== Kubernetes 1.27
-
-Kubernetes `1.27` is now available in Amazon EKS. For more information about Kubernetes `1.27`, see the https://kubernetes.io/blog/2023/04/11/kubernetes-v1-27-release/[official release announcement].
-
-[IMPORTANT]
-====
-
-
-* The support for the alpha `seccomp` annotations `seccomp.security.alpha.kubernetes.io/pod` and `container.seccomp.security.alpha.kubernetes.io` annotations was removed. The alpha `seccomp` annotations was deprecated in `1.19`, and with their removal in `1.27`, `seccomp` fields will no longer auto-populate for `Pods` with `seccomp` annotations. Instead, use the `securityContext.seccompProfile` field for `Pods` or containers to configure `seccomp` profiles. To check whether you are using the deprecated alpha `seccomp` annotations in your cluster, run the following command:
-+
-[source,bash,subs="verbatim,attributes"]
-----
-kubectl get pods --all-namespaces -o json | grep -E 'seccomp.security.alpha.kubernetes.io/pod|container.seccomp.security.alpha.kubernetes.io'
-----
-* The `--container-runtime` command line argument for the `kubelet` was removed. The default container runtime for Amazon EKS has been `containerd` since `1.24`, which eliminates the need to specify the container runtime. From `1.27` onwards, Amazon EKS will ignore the `--container-runtime` argument passed to any bootstrap scripts. It is important that you don't pass this argument to `--kubelet-extra-args` in order to prevent errors during the node bootstrap process. You must remove the `--container-runtime` argument from all of your node creation workflows and build scripts.
-
-====
-
-* The `kubelet` in Kubernetes `1.27` increased the default `kubeAPIQPS` to `50` and `kubeAPIBurst` to `100`. These enhancements allow the `kubelet` to handle a higher volume of API queries, improving response times and performance. When the demands for `Pods` increase, due to scaling requirements, the revised defaults ensure that the `kubelet` can efficiently manage the increased workload. As a result, `Pod` launches are quicker and cluster operations are more effective.
-* You can use more fine grained `Pod` topology to spread policies such as `minDomain`. This parameter gives you the ability to specify the minimum number of domains your `Pods` should be spread across. `nodeAffinityPolicy` and `nodeTaintPolicy` allow for an extra level of granularity in governing `Pod` distribution. This is in accordance to node affinities, taints, and the `matchLabelKeys` field in the `topologySpreadConstraints` of your `Pod's` specification. This permits the selection of `Pods` for spreading calculations following a rolling upgrade.
-* Kubernetes `1.27` promoted to beta a new policy mechanism for `StatefulSets` that controls the lifetime of their `PersistentVolumeClaims`(`PVCs`). The new `PVC` retention policy lets you specify if the `PVCs` generated from the `StatefulSet` spec template will be automatically deleted or retained when the `StatefulSet` is deleted or replicas in the `StatefulSet` are scaled down.
-* The https://kubernetes.io/docs/reference/command-line-tools-reference/kube-apiserver/[goaway-chance] option in the Kubernetes API server helps prevent `HTTP/2` client connections from being stuck on a single API server instance, by randomly closing a connection. When the connection is closed, the client will try to reconnect, and will likely land on a different API server as a result of load balancing. Amazon EKS version `1.27` has enabled `goaway-chance` flag. If your workload running on Amazon EKS cluster uses a client that is not compatible with https://www.rfc-editor.org/rfc/rfc7540#section-6.8[HTTP GOAWAY], we recommend that you update your client to handle `GOAWAY` by reconnecting on connection termination.
-
-For the complete Kubernetes `1.27` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md#changelog-since-v1260.
-

--- a/latest/ug/versioning/kubernetes-versions-standard.adoc
+++ b/latest/ug/versioning/kubernetes-versions-standard.adoc
@@ -110,25 +110,3 @@ Kubernetes `1.31` is now available in Amazon EKS. For more information about Kub
 * The PersistentVolume last phase transition time feature has graduated to stable and is now generally available for public use in Kubernetes version `1.31`. This feature introduces a new field, `.status.lastTransitionTime`, in the PersistentVolumeStatus, which provides a timestamp of when a PersistentVolume last transitioned to a different phase. This enhancement allows for better tracking and management of PersistentVolumes, particularly in scenarios where understanding the lifecycle of volumes is important.
 
 For the complete Kubernetes `1.31` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.31.md 
-
-[#kubernetes-1-30]
-== Kubernetes 1.30
-
-Kubernetes `1.30` is now available in Amazon EKS. For more information about Kubernetes `1.30`, see the https://kubernetes.io/blog/2024/04/17/kubernetes-v1-30-release/[official release announcement].
-
-[IMPORTANT]
-====
-
-
-* Starting with Amazon EKS version `1.30` or newer, any newly created managed node groups will automatically default to using Amazon Linux 2023 (AL2023) as the node operating system. Previously, new node groups would default to Amazon Linux 2 (AL2). You can continue to use AL2 by choosing it as the AMI type when creating a new node group. 
-** For information about migrating from AL2 to AL2023, see <<al2023>>.
-** For more information about Amazon Linux, see link:linux/al2023/ug/compare-with-al2.html[Comparing AL2 and AL2023,type="documentation"] in the Amazon Linux User Guide. 
-** For more information about specifiying the operating system for a managed node group, see <<create-managed-node-group>>.
-
-====
-
-* With Amazon EKS `1.30`, the `topology.k8s.aws/zone-id` label is added to worker nodes. You can use Availability Zone IDs (AZ IDs) to determine the location of resources in one account relative to the resources in another account. For more information, see link:ram/latest/userguide/working-with-az-ids.html[Availability Zone IDs for your {aws} resources,type="documentation"] in the _{aws} RAM User Guide_. 
-* Starting with `1.30`, Amazon EKS no longer includes the `default` annotation on the `gp2 StorageClass` resource applied to newly created clusters. This has no impact if you are referencing this storage class by name. You must take action if you were relying on having a default `StorageClass` in the cluster. You should reference the `StorageClass` by the name `gp2`. Alternatively, you can deploy the Amazon EBS recommended default storage class by setting the `defaultStorageClass.enabled` parameter to true when installing version `1.31.0` or later of the `aws-ebs-csi-driver add-on`. 
-* The minimum required IAM policy for the Amazon EKS cluster IAM role has changed. The action `ec2:DescribeAvailabilityZones` is required. For more information, see <<cluster-iam-role>>.
-
-For the complete Kubernetes `1.30` changelog, see https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.30.md.

--- a/latest/ug/versioning/kubernetes-versions.adoc
+++ b/latest/ug/versioning/kubernetes-versions.adoc
@@ -32,8 +32,6 @@ The following Kubernetes versions are currently available in Amazon EKS standard
 * `1.33`
 * `1.32`
 * `1.31`
-* `1.30`
-
 
 For important changes to be aware of for each version in standard support, see link:eks/latest/userguide/kubernetes-versions-standard.html[Kubernetes versions standard support,type="documentation"].
 
@@ -42,9 +40,9 @@ For important changes to be aware of for each version in standard support, see l
 
 The following Kubernetes versions are currently available in Amazon EKS extended support:
 
+* `1.30`
 * `1.29`
 * `1.28`
-* `1.27`
 
 For important changes to be aware of for each version in extended support, see link:eks/latest/userguide/kubernetes-versions-extended.html[Kubernetes versions extended support,type="documentation"].
 
@@ -108,12 +106,6 @@ https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/clus
 |September 26, 2023
 |November 26, 2024 
 |November 26, 2025
-
-|`1.27`
-|April 11, 2023
-|May 24, 2023
-|July 24, 2024
-|July 24, 2025
 
 |===
 


### PR DESCRIPTION
*Issue #, if available:*

none

*Description of changes:*

I saw some PR's already that only updated the versioning in a couple places, but not all. This serves as a comprehensive change to update all versioning related documentation for EKS.

- Removes 1.27 from extended support
- Moves 1.30 from standard to extended support

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
