### PR TITLE
Update auto-accelerated.adoc

### DIFF
--- a/latest/ug/automode/auto-accelerated.adoc
+++ b/latest/ug/automode/auto-accelerated.adoc
@@ -88,7 +88,6 @@ metadata:
   name: nvidia-smi
 spec:
   nodeSelector:
-    eks.amazonaws.com/instance-gpu-name: l40s
     eks.amazonaws.com/compute-type: auto
   restartPolicy: OnFailure
   containers:


### PR DESCRIPTION
Removing unnecessary nodeSelector from the pod spec that leaves the pod in the Pending state since the NodePool gpu can't satisfy this requirement

*Issue #, if available:*

*Description of changes:*

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
