### PR TITLE
Update docs for Auto Mode events name change

### DIFF
--- a/latest/ug/automode/auto-change.adoc
+++ b/latest/ug/automode/auto-change.adoc
@@ -14,9 +14,13 @@ To receive notifications of all source file changes to this specific documentati
 https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/automode/auto-change.adoc.atom
 ----
 
+== September 10, 2025
+
+*Chore:* Events fired from the Auto Mode Compute controller will now use the name `eks-auto-mode/compute` instead of `karpenter`.
+
 == August 24, 2025
 
-Bug Fix: VPCs that used a DHCP option set with a custom domain name that contained capital letters would cause Nodes to fail to join the cluster due to generating an invalid hostname. This has been resolved and domain names with capital letters now work correctly.
+*Bug Fix:* VPCs that used a DHCP option set with a custom domain name that contained capital letters would cause Nodes to fail to join the cluster due to generating an invalid hostname. This has been resolved and domain names with capital letters now work correctly.
 
 
 == August 15, 2025


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Updated auto change docs - Events fired from the Auto Mode Compute controller will now use the name `eks-auto-mode/compute` instead of `karpenter`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
