### PR TITLE
Update EBS CSI Doc on self-managed policy

### DIFF
--- a/latest/ug/storage/ebs-csi.adoc
+++ b/latest/ug/storage/ebs-csi.adoc
@@ -60,7 +60,8 @@ Pods will have access to the permissions that are assigned to the IAM role unles
 
 ====
 
-The following procedure shows you how to create an IAM role and attach the {aws} managed policy to it. To implement this procedure, you can use one of these tools:
+The following procedure shows you how to create an IAM role and attach the {aws} managed policy to it. Alternatively, you can create a self-managed policy with scoped-down permissions.
+To implement this procedure, you can use one of these tools:
 
 * <<eksctl_store_app_data>>
 * <<console_store_app_data>>

--- a/latest/ug/storage/ebs-csi.adoc
+++ b/latest/ug/storage/ebs-csi.adoc
@@ -60,13 +60,13 @@ Pods will have access to the permissions that are assigned to the IAM role unles
 
 ====
 
-The following procedure shows you how to create an IAM role and attach the {aws} managed policy to it. Alternatively, you can create a self-managed policy with scoped-down permissions.
-To implement this procedure, you can use one of these tools:
+The following procedure shows you how to create an IAM role and attach the {aws} managed policy to it. To implement this procedure, you can use one of these tools:
 
 * <<eksctl_store_app_data>>
 * <<console_store_app_data>>
 * <<awscli_store_app_data>>
 
+NOTE: You can create a self-managed policy with scoped-down permissions. Review link:aws-managed-policy/latest/reference/AmazonEBSCSIDriverPolicy.html[`AmazonEBSCSIDriverPolicy`,type="documentation"] and create a custom IAM Policy with reduced permissions. 
 
 [NOTE]
 ====


### PR DESCRIPTION
Attaching an AWS managed policy to the role when installing the EBS CSI Add-on (or any add-on) is not mandatory. Users can define and attach their own custom policies to the add-on role. This PR updates the wording to make that explicit.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
