### PR TITLE
Update warning on EKS Local Clusters in AWS Outposts AMI Compatibility

### DIFF
--- a/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
+++ b/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
@@ -10,6 +10,17 @@ include::../attributes.txt[]
 Learn how to launch Auto Scaling groups of Amazon Linux nodes on an Outpost that register with your Amazon EKS cluster. The cluster can be on the {aws} Cloud or on an Outpost.
 --
 
+[IMPORTANT]
+====
+Amazon EKS Local Clusters on Outposts currently supports only nodes created from Amazon EKS-optimized Amazon Linux 2 AMIs, which include:
+
+* Standard Amazon Linux 2 (`amazon-linux-2`)
+* GPU-enabled Amazon Linux 2 (`amazon-linux-2-gpu`)
+* Arm64-based Amazon Linux 2 (`amazon-linux-2-arm64`)
+
+Nodes based on Amazon Linux 2023 (`AL2023`) AMIs are not currently supported and will fail to join the cluster. Support for `AL2023`-based nodes is planned for a future release, and this documentation will be updated when the feature becomes available.
+====
+
 This topic describes how you can launch Auto Scaling groups of Amazon Linux nodes on an Outpost that register with your Amazon EKS cluster. The cluster can be on the {aws} Cloud or on an Outpost.
 
 * An existing Outpost. For more information, see link:outposts/latest/userguide/what-is-outposts.html[What is {aws} Outposts,type="documentation"].

--- a/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
+++ b/latest/ug/outposts/eks-outposts-self-managed-nodes.adoc
@@ -12,13 +12,13 @@ Learn how to launch Auto Scaling groups of Amazon Linux nodes on an Outpost that
 
 [IMPORTANT]
 ====
-Amazon EKS Local Clusters on Outposts currently supports only nodes created from Amazon EKS-optimized Amazon Linux 2 AMIs, which include:
+Amazon EKS Local Clusters on Outposts only supports nodes created from the following Amazon EKS-optimized Amazon Linux 2 AMIs:
 
 * Standard Amazon Linux 2 (`amazon-linux-2`)
 * GPU-enabled Amazon Linux 2 (`amazon-linux-2-gpu`)
 * Arm64-based Amazon Linux 2 (`amazon-linux-2-arm64`)
 
-Nodes based on Amazon Linux 2023 (`AL2023`) AMIs are not currently supported and will fail to join the cluster. Support for `AL2023`-based nodes is planned for a future release, and this documentation will be updated when the feature becomes available.
+Nodes on Local Clusters that run Amazon Linux 2023 (AL2023) AMIs aren't supported and fail to join the cluster.
 ====
 
 This topic describes how you can launch Auto Scaling groups of Amazon Linux nodes on an Outpost that register with your Amazon EKS cluster. The cluster can be on the {aws} Cloud or on an Outpost.

--- a/latest/ug/outposts/eks-outposts-troubleshooting.adoc
+++ b/latest/ug/outposts/eks-outposts-troubleshooting.adoc
@@ -271,7 +271,7 @@ The most common issues are the following:
 
 * AMI issues:
 +
-** You may be using an incompatible AMI. Only Amazon EKS optimized Amazon Linux 2 AMIs are currently supported (`amazon-linux-2`,`amazon-linux-2-gpu`, `amazon-linux-2-arm64`), attempting to join `AL2023`-based AMIs to EKS LocalClusters on {aws} Outposts will fail until the compatibility is added in a future release. See <<eks-outposts-self-managed-nodes,Create Amazon Linux nodes on {aws} Outposts>>)
+** You're using an incompatible AMI. Only Amazon EKS optimized Amazon Linux 2 AMIs are supported (`amazon-linux-2`,`amazon-linux-2-gpu`, `amazon-linux-2-arm64`). If you attempt to join AL2023 nodes to EKS LocalClusters on {aws} Outposts, the nodes fail to join the cluster. For more information, see <<eks-outposts-self-managed-nodes,Create Amazon Linux nodes on {aws} Outposts>>.
 ** If you used an {aws} CloudFormation template to create your nodes, make sure it wasn't using an unsupported AMI.
 * Missing the {aws} IAM Authenticator `ConfigMap` – If it's missing, you must create it. For more information, see <<aws-auth-configmap>> .
 * The wrong security group is used – Make sure to use `eks-cluster-sg-[.replaceable]``cluster-name``-[.replaceable]``uniqueid``` for your worker nodes' security group. The selected security group is changed by {aws} CloudFormation to allow a new security group each time the stack is used.

--- a/latest/ug/outposts/eks-outposts-troubleshooting.adoc
+++ b/latest/ug/outposts/eks-outposts-troubleshooting.adoc
@@ -271,7 +271,7 @@ The most common issues are the following:
 
 * AMI issues:
 +
-** You're using an unsupported AMI. You must use https://github.com/awslabs/amazon-eks-ami/releases/tag/v20220620[v20220620] or later for the <<eks-optimized-ami,Create nodes with optimized Amazon Linux AMIs>> Amazon EKS optimized Amazon Linux.
+** You may be using an incompatible AMI. Only Amazon EKS optimized Amazon Linux 2 AMIs are currently supported (`amazon-linux-2`,`amazon-linux-2-gpu`, `amazon-linux-2-arm64`), attempting to join `AL2023`-based AMIs to EKS LocalClusters on {aws} Outposts will fail until the compatibility is added in a future release. See <<eks-outposts-self-managed-nodes,Create Amazon Linux nodes on {aws} Outposts>>)
 ** If you used an {aws} CloudFormation template to create your nodes, make sure it wasn't using an unsupported AMI.
 * Missing the {aws} IAM Authenticator `ConfigMap` – If it's missing, you must create it. For more information, see <<aws-auth-configmap>> .
 * The wrong security group is used – Make sure to use `eks-cluster-sg-[.replaceable]``cluster-name``-[.replaceable]``uniqueid``` for your worker nodes' security group. The selected security group is changed by {aws} CloudFormation to allow a new security group each time the stack is used.


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Making it explicit that AL2023 is currently incompatible with EKS Local Clusters in AWS Outposts to aid troubleshooting until the planned support is released.

Many customers are starting to working on migration plan away from AL2 and this explicit callout will help preventing unnecessary troubleshooting on unsupported AL2023 IAM. The documentation will later be updated once the support is added on future release.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
