### PR TITLE
Update add-ons-images with ap-southeast-6

### DIFF
--- a/latest/ug/workloads/add-ons-images.adoc
+++ b/latest/ug/workloads/add-ons-images.adoc
@@ -33,6 +33,9 @@ When you deploy <<workloads-add-ons-available-eks,{aws} Amazon EKS add-ons>> to 
 |ap-southeast-4
 |491585149902.dkr.ecr.ap-southeast-4.amazonaws.com
 
+|ap-southeast-6
+|333609536671.dkr.ecr.ap-southeast-6.amazonaws.com
+
 |ap-south-1
 |602401143452.dkr.ecr.ap-south-1.amazonaws.com
 


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Add ap-southeast-6, New Zealand, to the list of ECR registries used by EKS.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
