### PR TITLE
Update EKS 1.34 release notes

### DIFF
--- a/latest/ug/versioning/kubernetes-versions-standard.adoc
+++ b/latest/ug/versioning/kubernetes-versions-standard.adoc
@@ -27,7 +27,7 @@ Kubernetes `1.34` is now available in Amazon EKS. For more information about Kub
 * AppArmor is deprecated in Kubernetes 1.34.
 ** We recommend migrating to alternative container security solutions like link:https://kubernetes.io/docs/tutorials/security/seccomp/[seccomp] or link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod Security Standards].
 * VolumeAttributesClass (VAC) graduates to GA in Kubernetes 1.34, migrating from the beta API (`storage.k8s.io/v1beta1`) to the stable API (`storage.k8s.io/v1`).
-** If you use the EBS CSI driver with {aws}-managed sidecar containers (from link:https://gallery.ecr.aws/csi-components[]), volume modification will continue to work seamlessly on EKS 1.31-1.33 clusters. {aws} will patch the sidecars to support beta VAC APIs until the end of EKS 1.33 standard support (July 29, 2026).
+** If you use the EBS CSI driver with {aws}-managed sidecar containers (from link:https://gallery.ecr.aws/csi-components[CSI Components] on the ECR Gallery), volume modification will continue to work seamlessly on EKS 1.31-1.33 clusters. {aws} will patch the sidecars to support beta VAC APIs until the end of EKS 1.33 standard support (July 29, 2026).
 ** If you self-manage your CSI sidecar containers, you may need to pin to older sidecar versions on pre-1.34 clusters to maintain VAC functionality.
 ** To use GA VolumeAttributesClass features (such as modification rollback), upgrade to EKS 1.34 or later.
 

--- a/latest/ug/versioning/kubernetes-versions-standard.adoc
+++ b/latest/ug/versioning/kubernetes-versions-standard.adoc
@@ -26,16 +26,18 @@ Kubernetes `1.34` is now available in Amazon EKS. For more information about Kub
 ** For more information, see <<al2-ami-deprecation>>.
 * AppArmor is deprecated in Kubernetes 1.34.
 ** We recommend migrating to alternative container security solutions like link:https://kubernetes.io/docs/tutorials/security/seccomp/[seccomp] or link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Pod Security Standards].
-* VolumeAttributesClass (VAC) graduates to GA in Kubernetes 1.34 and only supports the GA version.
-** Clusters running 1.33 or older (using the beta API) with the latest EBS CSI driver may experience VolumeModification failures.
-** {aws} is patching the EBS CSI sidecars to support both beta and GA versions until the end of EKS 1.33 standard support.
-** For EBS CSI driver compatibility, ensure you're using version 1.50 or later with Kubernetes 1.34.
+* VolumeAttributesClass (VAC) graduates to GA in Kubernetes 1.34, migrating from the beta API (`storage.k8s.io/v1beta1`) to the stable API (`storage.k8s.io/v1`).
+** If you use the EBS CSI driver with {aws}-managed sidecar containers (from link:https://gallery.ecr.aws/csi-components[]), volume modification will continue to work seamlessly on EKS 1.31-1.33 clusters. {aws} will patch the sidecars to support beta VAC APIs until the end of EKS 1.33 standard support (July 29, 2026).
+** If you self-manage your CSI sidecar containers, you may need to pin to older sidecar versions on pre-1.34 clusters to maintain VAC functionality.
+** To use GA VolumeAttributesClass features (such as modification rollback), upgrade to EKS 1.34 or later.
 
 ====
 
 * *Dynamic Resource Allocation (DRA) Core APIs (GA):* Dynamic Resource Allocation has graduated to stable, enabling efficient management of specialized hardware like GPUs through standardized allocation interfaces - simplifying resource management for hardware accelerators and improving utilization of specialized resources.
 * *Projected ServiceAccount Tokens for Kubelet (Beta):* This enhancement improves security by using short-lived credentials for container image pulls instead of long-lived secrets - reducing the risk of credential exposure and strengthening the overall security posture of your clusters.
 * *Pod-level Resource Requests and Limits (Beta):* This feature simplifies resource management by allowing shared resource pools for multi-container pods - enabling more efficient resource allocation and utilization for complex applications with multiple containers.
+* *Mutable CSI Node Allocatable Count (Beta):* The `MutableCSINodeAllocatableCount` feature gate is enabled by default in EKS 1.34, making the CSINode max attachable volume count attribute mutable and introducing a mechanism to update it dynamically based on user configuration at the CSI driver level. These updates can be triggered either by periodic intervals or by failure detection, enhancing the reliability of stateful pod scheduling by addressing mismatches between reported and actual attachment capacity on nodes.
+** For more information, see link:https://kubernetes.io/blog/2025/09/11/kubernetes-v1-34-mutable-csi-node-allocatable-count/[Kubernetes v1.34: Mutable CSI Node Allocatable Count] on the _Kubernetes Blog_.
 * *Deprecation Notice - cgroup driver configuration:* Manual cgroup driver configuration is being deprecated in favor of automatic detection.
 ** *Customer impact:* If you currently set the `--cgroup-driver` flag manually in your kubelet configuration, you should prepare to remove this configuration.
 ** *Required action:* Plan to update node bootstrap scripts and custom AMI configurations to remove manual cgroup driver settings before the feature is removed in a future Kubernetes release.


### PR DESCRIPTION
The existing release notes for EKS 1.34 are misleading for VAC (VolumeAttributeClass) changes and incomplete for `MutableCSINodeAllocatableCount`.