### PR TITLE
Remove note about IAM role usage for Windows nodes

### DIFF
--- a/latest/ug/clusters/windows-support.adoc
+++ b/latest/ug/clusters/windows-support.adoc
@@ -21,7 +21,6 @@ Before deploying Windows nodes, be aware of the following considerations.
 * You can use host networking on Windows nodes using `HostProcess` Pods. For more information, see https://kubernetes.io/docs/tasks/configure-pod-container/create-hostprocess-pod/[Create a Windows HostProcessPod] in the Kubernetes documentation.
 * Amazon EKS clusters must contain one or more Linux or Fargate nodes to run core system Pods that only run on Linux, such as CoreDNS.
 * The `kubelet` and `kube-proxy` event logs are redirected to the `EKS Windows` Event Log and are set to a 200 MB limit.
-* You can't use the same IAM role for both Linux and Windows nodes. 
 * You can't use <<security-groups-for-pods,Assign security groups to individual pods>> with Pods running on Windows nodes.
 * You can't use <<cni-custom-network,custom networking>> with Windows nodes.
 * You can't use `IPv6` with Windows nodes.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The statement says that you can't use the same IAM role for Linux and Windows - this is incorrect. 
You you can use the same IAM role for Linux and Windows - scenario: Instead of relying on access entries, I can keep one entry in aws-auth configmap and that should work for me. 

Instead, we can say that it is recommended to create a separate IAM role. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
