### PR TITLE
Update EKS Auto Fault Injection Service support details

### DIFF
--- a/latest/ug/automode/automode-learn-instances.adoc
+++ b/latest/ug/automode/automode-learn-instances.adoc
@@ -128,13 +128,13 @@ For more information about the Amazon EC2 Instance Metadata Service (IMDS), see 
 ** Auto Mode skips the small EBS volume.
 ** The NVMe drive(s) are exposed directly for your workload.
 * Amazon EKS Auto Mode does not support the following {aws} Fault Injection Service actions:
-** ec2:RebootInstances
-** ec2:SendSpotInstanceInterruptions
-** ec2:StartInstances
-** ec2:StopInstances
-** ec2:TerminateInstances
-** ec2:PauseVolumeIO
-* Amazon EKS Auto Mode supports {aws} Fault Injection Service EKS Pod actions. For more information see link:resilience-hub/latest/userguide/testing.html["Managing Fault Injection Service experiments",type="documentation"] and link:https://docs.aws.amazon.com/fis/latest/userguide/eks-pod-actions.html#configure-service-account["Use the AWS FIS aws:eks:pod actions",type="documentation"] in the {aws} Resilience Hub User Guide.
+** `ec2:RebootInstances`
+** `ec2:SendSpotInstanceInterruptions`
+** `ec2:StartInstances`
+** `ec2:StopInstances`
+** `ec2:TerminateInstances`
+** `ec2:PauseVolumeIO`
+* Amazon EKS Auto Mode supports {aws} Fault Injection Service EKS Pod actions. For more information, see link:resilience-hub/latest/userguide/testing.html[Managing Fault Injection Service experiments,type="documentation"] and link:fis/latest/userguide/eks-pod-actions.html#configure-service-account[Use the AWS FIS aws:eks:pod actions,type="documentation"] in the {aws} Resilience Hub User Guide.
 * You do not need to install the `Neuron Device Plugin` on EKS Auto Mode nodes.
 +
 If you have other types of nodes in your cluster, you need to configure the Neuron Device plugin to not run on Auto Mode nodes. For more information, see <<associate-workload>>.

--- a/latest/ug/automode/automode-learn-instances.adoc
+++ b/latest/ug/automode/automode-learn-instances.adoc
@@ -127,7 +127,14 @@ For more information about the Amazon EC2 Instance Metadata Service (IMDS), see 
 * When `ephemeralStorage.size` equals or exceeds the local NVMe capacity, the following actions occur:
 ** Auto Mode skips the small EBS volume.
 ** The NVMe drive(s) are exposed directly for your workload.
-* Amazon EKS Auto Mode does not support {aws} Fault Injection Service. For more information, see link:resilience-hub/latest/userguide/testing.html["Managing Fault Injection Service experiments",type="documentation"] in the {aws} Resilience Hub User Guide. 
+* Amazon EKS Auto Mode does not support the following {aws} Fault Injection Service actions:
+** ec2:RebootInstances
+** ec2:SendSpotInstanceInterruptions
+** ec2:StartInstances
+** ec2:StopInstances
+** ec2:TerminateInstances
+** ec2:PauseVolumeIO
+* Amazon EKS Auto Mode supports {aws} Fault Injection Service EKS Pod actions. For more information see link:resilience-hub/latest/userguide/testing.html["Managing Fault Injection Service experiments",type="documentation"] and link:https://docs.aws.amazon.com/fis/latest/userguide/eks-pod-actions.html#configure-service-account["Use the AWS FIS aws:eks:pod actions",type="documentation"] in the {aws} Resilience Hub User Guide.
 * You do not need to install the `Neuron Device Plugin` on EKS Auto Mode nodes.
 +
 If you have other types of nodes in your cluster, you need to configure the Neuron Device plugin to not run on Auto Mode nodes. For more information, see <<associate-workload>>.


### PR DESCRIPTION
Clarified Amazon EKS Auto Mode support for Fault Injection Service actions and added details on supported and unsupported actions.

*Description of changes:* Documentation states that EKS Auto does not support AWS FIS. Tested that the AWS FIS Pod actions do work so updating documentation to reflect that.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
