### PR TITLE
Highlight the generated key for NodeDiagnostic should be ends with .tar.gz

### DIFF
--- a/latest/ug/nodes/auto-get-logs.adoc
+++ b/latest/ug/nodes/auto-get-logs.adoc
@@ -30,14 +30,14 @@ If you don't already have an S3 bucket to store the logs, create one. Use the fo
 
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
-aws s3api create-bucket --bucket [.replaceable]`bucket-name`
+aws s3api create-bucket --bucket [.replaceable]`<bucket-name>`
 ----
 
 == Step 2: Create pre-signed S3 URL for HTTP Put
 
 Amazon EKS returns the node logs by doing a HTTP PUT operation to a URL you specify. In this tutorial, we will generate a pre-signed S3 HTTP PUT URL. 
 
-The logs will be returned as a gzip tarball, with the [.replaceable]`.tar.gz` extension.
+The logs will be returned as a gzip tarball, with the `.tar.gz` extension.
 
 [NOTE]
 ====
@@ -45,7 +45,7 @@ You must use the {aws} API or a SDK to create the pre-signed S3 upload URL for E
 ====
 
 . Determine where in the bucket you want to store the logs. For example, you might use [.replaceable]`2024-11-12/logs1.tar.gz` as the key.
-. Save the following Python code to the file [.replaceable]`presign-upload.py`. Replace [.replaceable]`<bucket-name>` and [.replaceable]`<key>`. The key should end with [.replaceable]`.tar.gz`.
+. Save the following Python code to the file [.replaceable]`presign-upload.py`. Replace [.replaceable]`<bucket-name>` and [.replaceable]`<key>`. The key should end with `.tar.gz`.
 +
 [source,python,subs="verbatim,attributes"]
 ----
@@ -78,7 +78,7 @@ resource's name, and providing a HTTP PUT URL destination.
 apiVersion: eks.amazonaws.com/v1alpha1
 kind: NodeDiagnostic
 metadata:
-    name: [.replaceable]`node-name`
+    name: [.replaceable]`<node-name>`
 spec:
     logCapture:
         destination: [.replaceable]`http-put-destination`
@@ -101,7 +101,7 @@ You can check on the Status of the collection by describing the
 
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
-kubectl describe nodediagnostics.eks.amazonaws.com/[.replaceable]`node-name`
+kubectl describe nodediagnostics.eks.amazonaws.com/[.replaceable]`<node-name>`
 ----
 
 == Step 4: Download logs from S3
@@ -111,7 +111,7 @@ Wait approximately one minute before attempting to download the logs. Then, use 
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
 # Once NodeDiagnostic shows Success status, download the logs
-aws s3 cp s3://[.replaceable]`bucket-name`/[.replaceable]`key` ./path-to-node-logs.tar.gz
+aws s3 cp s3://[.replaceable]`<bucket-name>`/[.replaceable]`key` ./[.replaceable]`<path-to-node-logs>`.tar.gz
 ----
 
 == Step 5: Clean up NodeDiagnostic resource
@@ -123,5 +123,5 @@ artifacts
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
 # Delete the NodeDiagnostic resource
-kubectl delete nodediagnostics.eks.amazonaws.com/[.replaceable]`node-name`
+kubectl delete nodediagnostics.eks.amazonaws.com/[.replaceable]`<node-name>`
 ----

--- a/latest/ug/nodes/auto-get-logs.adoc
+++ b/latest/ug/nodes/auto-get-logs.adoc
@@ -37,22 +37,22 @@ aws s3api create-bucket --bucket [.replaceable]`bucket-name`
 
 Amazon EKS returns the node logs by doing a HTTP PUT operation to a URL you specify. In this tutorial, we will generate a pre-signed S3 HTTP PUT URL. 
 
-The logs will be returned as a gzip tarball, with the `.tar.gz` extension.
+The logs will be returned as a gzip tarball, with the [.replaceable]`.tar.gz` extension.
 
 [NOTE]
 ====
 You must use the {aws} API or a SDK to create the pre-signed S3 upload URL for EKS to upload the log file. You cannot create a pre-signed S3 upload URL using the {aws} CLI.  
 ====
 
-. Determine where in the bucket you want to store the logs. For example, you might use `2024-11-12/logs1.tar.gz` as the key. 
-. Save the following Python code to the file `presign-upload.py`. Replace `<bucket-name>` and `<key>`. The key should end with `.tar.gz`.
+. Determine where in the bucket you want to store the logs. For example, you might use [.replaceable]`2024-11-12/logs1.tar.gz` as the key.
+. Save the following Python code to the file [.replaceable]`presign-upload.py`. Replace [.replaceable]`<bucket-name>` and [.replaceable]`<key>`. The key should end with [.replaceable]`.tar.gz`.
 +
 [source,python,subs="verbatim,attributes"]
 ----
 import boto3; print(boto3.client('s3').generate_presigned_url(
    ClientMethod='put_object',
-   Params={'Bucket': '<bucket-name>', 'Key': '<key>'},
-   ExpiresIn=1000
+   Params={'Bucket': '[.replaceable]`<bucket-name>`', 'Key': '[.replaceable]`<key>`'},
+   ExpiresIn=[.replaceable]`1000`
 ))
 ----
 . Run the script with
@@ -111,7 +111,7 @@ Wait approximately one minute before attempting to download the logs. Then, use 
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
 # Once NodeDiagnostic shows Success status, download the logs
-aws s3 cp s3://[.replaceable]`bucket-name`/[.replaceable]`key` ./node-logs.tar.gz
+aws s3 cp s3://[.replaceable]`bucket-name`/[.replaceable]`key` ./path-to-node-logs.tar.gz
 ----
 
 == Step 5: Clean up NodeDiagnostic resource


### PR DESCRIPTION
*Issue #, if available:*

If the key of the object is not ends with `.tar.gz`, it might lead to an error.

```bash
$ kubectl describe NodeDiagnostic
Name:         ...
...
Spec:
  Log Capture:
    Categories:
      All
    Destination:  ...
Status:
  Capture Statuses:
    State:
      Completed:
        ...
        Message:      fatal error during log upload process
        Reason:       Failure
        ...
    Type:             Log
Events:               <none>
```


*Description of changes:*

Highlight the variables for the parts that user should deal with care.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
