### PR TITLE
Added command and rectified document

### DIFF
--- a/latest/ug/cluster-management/cost-monitoring-kubecost-view-dashboard.adoc
+++ b/latest/ug/cluster-management/cost-monitoring-kubecost-view-dashboard.adoc
@@ -19,7 +19,6 @@ kubectl get pods --namespace kubecost
 
 . On your device, enable port-forwarding to expose the Kubecost dashboard.
 +
-[NOTE]
 * If kubecost is installed using helm:
 +
 [source,bash,subs="verbatim,attributes"]

--- a/latest/ug/cluster-management/cost-monitoring-kubecost-view-dashboard.adoc
+++ b/latest/ug/cluster-management/cost-monitoring-kubecost-view-dashboard.adoc
@@ -19,9 +19,19 @@ kubectl get pods --namespace kubecost
 
 . On your device, enable port-forwarding to expose the Kubecost dashboard.
 +
+[NOTE]
+* If kubecost is installed using helm:
++
 [source,bash,subs="verbatim,attributes"]
 ----
 kubectl port-forward deployment/kubecost-cost-analyzer 9090 --namespace kubecost
+----
+
+* If kubecost is installed using Amazon EKS add-on:
++
+[source,bash,subs="verbatim,attributes"]
+----
+kubectl port-forward deployment/cost-analyzer 9090 --namespace kubecost
 ----
 +
 Alternatively, you can use the <<aws-load-balancer-controller,{aws} Load Balancer Controller>> to expose Kubecost and use Amazon Cognito for authentication, authorization, and user management. For more information, see link:containers/how-to-use-application-load-balancer-and-amazon-cognito-to-authenticate-users-for-your-kubernetes-web-apps[How to use Application Load Balancer and Amazon Cognito to authenticate users for your Kubernetes web apps,type="blog"].


### PR DESCRIPTION
*Issue #, if available:*

- Current kubecost document has command to expose kubecost deployment when installed via helm. 
- If a user has installed the kubecost deployment via Amazon EKS add-on, then the command given in the current document fails as when kubecost is installed via addon `cost-analyzer` deployment is created.

*Description of changes:*

- Hence have added the command to expose kubecost deployment when installed via addon and rectified the wordings accordingly


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


