### PR TITLE
Changed the sed logic to exclude the terminating pattern '---'

### DIFF
--- a/latest/ug/networking/lbc-manifest.adoc
+++ b/latest/ug/networking/lbc-manifest.adoc
@@ -229,7 +229,7 @@ curl -Lo v2_14_1_full.yaml https://github.com/kubernetes-sigs/aws-load-balancer-
 +
 [source,shell,subs="verbatim,attributes"]
 ----
-sed -i.bak -e '764,773d' ./v2_14_1_full.yaml
+sed -i.bak -e '764,772d' ./v2_14_1_full.yaml
 ----
 +
 If you downloaded a different file version, then open the file in an editor and remove the following lines.  


### PR DESCRIPTION
*Issue #, if available:*
With the current documentation, the sed logic was excluding the terminating pattern '---' which caused the following error when applying "kubectl apply -f v2_14_1_full.yaml"

```
Error from server (BadRequest): error when creating "v2_14_1_full.yaml": Role in version "v1" cannot be handled as a Role: strict decoding error: unknown field "spec"
```

*Description of changes:*
Changed the sed logic to exclude the terminating pattern '---' from being removed

Test:
Executed the "sed -i.bak -e '764,773d' ./v2_14_1_full.yaml" and verified that the file is correctly created.
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
