### PR TITLE
Add server-tls-bootstrap and ecr-credential-provider configuration to Hybrid Nodes Bottlerocket settings

### DIFF
--- a/latest/ug/nodes/hybrid-nodes-bottlerocket.adoc
+++ b/latest/ug/nodes/hybrid-nodes-bottlerocket.adoc
@@ -10,9 +10,9 @@ include::../attributes.txt[]
 Connect hybrid nodes running Bottlerocket to an Amazon EKS cluster.
 --
 
-This topic describes how to connect hybrid nodes running Bottlerocket to an Amazon EKS cluster. link:bottlerocket/[Bottlerocket,type="marketing"] is an open source Linux distribution that is sponsored and supported by {aws}. Bottlerocket is purpose-built for hosting container workloads. With Bottlerocket, you can improve the availability of containerized deployments and reduce operational costs by automating updates to your container infrastructure. Bottlerocket includes only the essential software to run containers, which improves resource usage, reduces security threats, and lowers management overhead. 
+This topic describes how to connect hybrid nodes running Bottlerocket to an Amazon EKS cluster. link:bottlerocket/[Bottlerocket,type="marketing"] is an open source Linux distribution that is sponsored and supported by {aws}. Bottlerocket is purpose-built for hosting container workloads. With Bottlerocket, you can improve the availability of containerized deployments and reduce operational costs by automating updates to your container infrastructure. Bottlerocket includes only the essential software to run containers, which improves resource usage, reduces security threats, and lowers management overhead.
 
-Only VMware variants of Bottlerocket version v1.37.0 and above are supported with EKS Hybrid Nodes. VMware variants of Bottlerocket are available for Kubernetes versions v1.28 and above. The OS images for these variants include the kubelet, containerd, aws-iam-authenticator and other software prerequisites for EKS Hybrid Nodes. You can configure these components using a Bottlerocket https://github.com/bottlerocket-os/bottlerocket?tab=readme-ov-file#settings[settings] file that includes base64 encoded user-data for the Bottlerocket bootstrap and admin containers. Configuring these settings enables Bottlerocket to use your hybrid nodes credentials provider to authenticate hybrid nodes to your cluster. After your hybrid nodes join the cluster, they will appear with status `Not Ready` in the Amazon EKS console and in Kubernetes-compatible tooling such as `kubectl`. After completing the steps on this page, proceed to <<hybrid-nodes-cni>> to make your hybrid nodes ready to run applications.
+Only VMware variants of Bottlerocket version v1.37.0 and above are supported with EKS Hybrid Nodes. VMware variants of Bottlerocket are available for Kubernetes versions v1.28 and above. The OS images for these variants include the kubelet, containerd, aws-iam-authenticator and other software prerequisites for EKS Hybrid Nodes. You can configure these components using a Bottlerocket https://github.com/bottlerocket-os/bottlerocket#settings[settings] file that includes base64 encoded user-data for the Bottlerocket bootstrap and admin containers. Configuring these settings enables Bottlerocket to use your hybrid nodes credentials provider to authenticate hybrid nodes to your cluster. After your hybrid nodes join the cluster, they will appear with status `Not Ready` in the Amazon EKS console and in Kubernetes-compatible tooling such as `kubectl`. After completing the steps on this page, proceed to <<hybrid-nodes-cni>> to make your hybrid nodes ready to run applications.
 
 == Prerequisites
 
@@ -25,7 +25,12 @@ Before connecting hybrid nodes to your Amazon EKS cluster, make sure you have co
 
 == Step 1: Create the Bottlerocket settings TOML file
 
-To configure Bottlerocket for hybrid nodes, you need to create a `settings.toml` file with the necessary configuration. The contents of the TOML file will differ based on the credential provider you are using (SSM or IAM Roles Anywhere). This file will be passed as user data when provisioning the Bottlerocket instance. 
+To configure Bottlerocket for hybrid nodes, you need to create a `settings.toml` file with the necessary configuration. The contents of the TOML file will differ based on the credential provider you are using (SSM or IAM Roles Anywhere). This file will be passed as user data when provisioning the Bottlerocket instance.
+
+[NOTE]
+====
+The TOML files provided below only represent the minimum required settings for initializing a Bottlerocket VMWare machine as a node on an EKS cluster. Bottlerocket provides a wide range of settings to address several different use cases, so for further configuration options beyond hybrid node initialization, please refer to the https://bottlerocket.dev/en[Bottlerocket documentation] for the comprehensive list of all documented settings for the Bottlerocket version you are using (for example, https://bottlerocket.dev/en/os/1.51.x/api/settings-index[here] are all the settings available for Bottlerocket 1.51.x).
+====
 
 === SSM
 
@@ -41,12 +46,35 @@ hostname-override = "<hostname>"
 provider-id = "eks-hybrid:///<region>/<cluster-name>/<hostname>"
 authentication-mode = "aws"
 cloud-provider = ""
+server-tls-bootstrap = true
 
 [settings.network]
 hostname = "<hostname>"
 
 [settings.aws]
 region = "<region>"
+
+[settings.kubernetes.credential-providers.ecr-credential-provider]
+enabled = true
+cache-duration = "12h"
+image-patterns = [
+    "*.dkr.ecr.*.amazonaws.com",
+    "*.dkr.ecr.*.amazonaws.com.cn",
+    "*.dkr.ecr.*.amazonaws.eu",
+    "*.dkr-ecr.*.on.aws",
+    "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+    "*.dkr.ecr-fips.*.amazonaws.com",
+    "*.dkr.ecr-fips.*.amazonaws.eu",
+    "*.dkr.ecr.*.cloud.adc-e.uk",
+    "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+    "*.dkr.ecr.*.c2s.ic.gov",
+    "*.dkr.ecr-fips.*.c2s.ic.gov",
+    "*.dkr.ecr.*.sc2s.sgov.gov",
+    "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+    "*.dkr.ecr.*.csp.hci.ic.gov",
+    "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+    "public.ecr.aws"
+]
 
 [settings.kubernetes.node-labels]
 "eks.amazonaws.com/compute-type" = "hybrid"
@@ -106,6 +134,7 @@ hostname-override = "<hostname>"
 provider-id = "eks-hybrid:///<region>/<cluster-name>/<hostname>"
 authentication-mode = "aws"
 cloud-provider = ""
+server-tls-bootstrap = true
 
 [settings.network]
 hostname = "<hostname>"
@@ -113,6 +142,28 @@ hostname = "<hostname>"
 [settings.aws]
 region = "<region>"
 config = "<base64-encoded-aws-config-file>"
+
+[settings.kubernetes.credential-providers.ecr-credential-provider]
+enabled = true
+cache-duration = "12h"
+image-patterns = [
+    "*.dkr.ecr.*.amazonaws.com",
+    "*.dkr.ecr.*.amazonaws.com.cn",
+    "*.dkr.ecr.*.amazonaws.eu",
+    "*.dkr-ecr.*.on.aws",
+    "*.dkr-ecr.*.on.amazonwebservices.com.cn",
+    "*.dkr.ecr-fips.*.amazonaws.com",
+    "*.dkr.ecr-fips.*.amazonaws.eu",
+    "*.dkr.ecr.*.cloud.adc-e.uk",
+    "*.dkr.ecr-fips.*.cloud.adc-e.uk",
+    "*.dkr.ecr.*.c2s.ic.gov",
+    "*.dkr.ecr-fips.*.c2s.ic.gov",
+    "*.dkr.ecr.*.sc2s.sgov.gov",
+    "*.dkr.ecr-fips.*.sc2s.sgov.gov",
+    "*.dkr.ecr.*.csp.hci.ic.gov",
+    "*.dkr.ecr-fips.*.csp.hci.ic.gov",
+    "public.ecr.aws"
+]
 
 [settings.kubernetes.node-labels]
 "eks.amazonaws.com/compute-type" = "hybrid"
@@ -194,7 +245,7 @@ govc vm.create \
     -template=<template-name> \
     <vm-name>
 
-govc vm.change 
+govc vm.change
     -vm <vm-name> \
     -e guestinfo.userdata="$(base64 -w0 settings.toml)" \
     -e guestinfo.userdata.encoding="base64"


### PR DESCRIPTION
Add `server-tls-bootstrap` and `ecr-credential-provider` configuration to Hybrid Nodes Bottlerocket settings.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
