### PR TITLE
Fix incorrect CLI flag from --bootstrapSelfManagedAddons to --no-bootstrap-self-managed-addons

### DIFF
--- a/latest/ug/clusters/create-cluster.adoc
+++ b/latest/ug/clusters/create-cluster.adoc
@@ -229,7 +229,7 @@ The following are optional settings that, if required, must be added to the prev
 +
 If you'd like to disable the installation of these default networking add-ons, use the parameter below. This may be used for alternate CNIs, such as Cilium. Review the link:eks/latest/APIReference/API_CreateCluster.html[EKS API reference,type="documentation"] for more information. 
 +
-`aws eks create-cluster --bootstrapSelfManagedAddons false`
+`aws eks create-cluster --no-bootstrap-self-managed-addons ...`
 ** If you want to specify which `IPv4` Classless Inter-domain Routing (CIDR) block Kubernetes assigns service IP addresses from, you must specify it by adding the `--kubernetes-network-config serviceIpv4Cidr=<cidr-block>` to the following command.
 +
 Specifying your own range can help prevent conflicts between Kubernetes services and other networks peered or connected to your VPC. Enter a range in CIDR notation. For example: `10.2.0.0/16`.


### PR DESCRIPTION
**Description of changes:**

Corrects the CLI flag for disabling default networking add-ons from the incorrect `--bootstrapSelfManagedAddons false` to the correct `--no-bootstrap-self-managed-addons`.


**Refs**

https://docs.aws.amazon.com/cli/latest/reference/eks/create-cluster.html
> [--bootstrap-self-managed-addons | --no-bootstrap-self-managed-addons]

**Verification**

- When using the incorrect --bootstrapSelfManagedAddon flag, an error occurs:

  ```
  aws eks create-cluster \
  --bootstrapSelfManagedAddons false \
  --name cluster-from-cli --role-arn '...' \
  --resources-vpc-config \
      subnetIds=...

  usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
  To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help

  Unknown options: --bootstrapSelfManagedAddons, false
  ```

- Using --no-bootstrap-self-managed-addons successfully creates the cluster:

  ```
  ❯ aws eks create-cluster \
  --no-bootstrap-self-managed-addons  \
  --name cluster-from-cli --role-arn '...' \
  --resources-vpc-config \
      subnetIds=...
  {
      "cluster": 
      ...
  }
  ```


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
