### PR TITLE
Fix broken RSS feed URLs after path change

### DIFF
--- a/latest/ug/versioning/kubernetes-versions.adoc
+++ b/latest/ug/versioning/kubernetes-versions.adoc
@@ -61,7 +61,7 @@ To receive notifications of all source file changes to this specific documentati
 
 [source,none]
 ----
-https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/clusters/kubernetes-versions.adoc.atom
+https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/versioning/kubernetes-versions.adoc.atom
 ----
 
 [%header,cols="5"]

--- a/latest/ug/versioning/platform-versions.adoc
+++ b/latest/ug/versioning/platform-versions.adoc
@@ -34,7 +34,7 @@ To receive notifications of all source file changes to this specific documentati
 
 [source,none]
 ----
-https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/clusters/platform-versions.adoc.atom
+https://github.com/awsdocs/amazon-eks-user-guide/commits/mainline/latest/ug/versioning/platform-versions.adoc.atom
 ----
 
 


### PR DESCRIPTION
*Issue #, if available:* No

*Description of changes:*

When kubernetes-versions.adoc and platform-versions.adoc were moved from latest/ug/clusters/ to latest/ug/versioning/, the RSS feed URLs in both files were not updated. This broke the feeds because they still pointed to the old paths.

*Solution*
Updated the RSS feed URLs in both files to match the new paths:
kubernetes-versions.adoc: Changed from /clusters/kubernetes-versions.adoc.atom to /versioning/kubernetes-versions.adoc.atom
platform-versions.adoc: Changed from /clusters/platform-versions.adoc.atom to /versioning/platform-versions.adoc.atom

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
