### PR TITLE
Add documentation for configuring advanced security spec in nodeclass

### DIFF
--- a/latest/ug/automode/auto-advanced-security.adoc
+++ b/latest/ug/automode/auto-advanced-security.adoc
@@ -1,0 +1,75 @@
+include::../attributes.txt[]
+
+[.topic]
+[#auto-advanced-security]
+= Configure advanced security settings for nodes
+:info_titleabbrev: Advanced security
+
+This topic describes how to configure advanced security settings for Amazon EKS Auto Mode nodes using the `advancedSecurity` specification in your Node Class.
+
+== Prerequisites
+
+Before you begin, ensure you have:
+
+* An Amazon EKS Auto Mode cluster. For more information, see <<create-auto>>.
+* `kubectl` installed and configured. For more information, see <<setting-up>>.
+* Understanding of Node Class configuration. For more information, see <<create-node-class>>.
+
+== Configure advanced security settings
+
+To configure advanced security settings for your nodes, set the `advancedSecurity` fields in your Node Class specification:
+
+[source,yaml]
+----
+apiVersion: eks.amazonaws.com/v1
+kind: NodeClass
+metadata:
+  name: security-hardened
+spec:
+  role: MyNodeRole
+  
+  subnetSelectorTerms:
+    - tags:
+        Name: "private-subnet"
+  
+  securityGroupSelectorTerms:
+    - tags:
+        Name: "eks-cluster-sg"
+  
+  advancedSecurity:
+    # Enable FIPS-compliant AMIs (US regions only)
+    fips: true
+    
+    # Configure kernel lockdown mode
+    kernelLockdown: "integrity"
+----
+
+Apply this configuration:
+
+[source,bash]
+----
+kubectl apply -f nodeclass.yaml
+----
+
+Reference this Node Class in your Node Pool configuration. For more information, see <<create-node-pool>>.
+
+== Field descriptions
+
+* `fips` (boolean, optional): When set to `true`, provisions nodes using AMIs with FIPS 140-2 validated cryptographic modules. This setting selects FIPS-compliant AMIs; customers are responsible for managing their compliance requirements. For more information, see https://aws.amazon.com/compliance/fips/[AWS FIPS compliance]. If you specify `fips: true` in a non-US region, node provisioning will fail. Default: `false`.
+
+* `kernelLockdown` (string, optional): Controls the kernel lockdown security module mode. Accepted values:
+** `integrity`: Blocks methods for overwriting kernel memory or modifying kernel code. Prevents unsigned kernel modules from loading.
+** `none`: Disables kernel lockdown protection.
++
+For more information, see https://man7.org/linux/man-pages/man7/kernel_lockdown.7.html[Linux kernel lockdown documentation].
+
+== Considerations
+
+* FIPS-compliant AMIs are available in AWS US East/West, AWS GovCloud (US), and AWS Canada (Central/West) Regions. For more information, see https://aws.amazon.com/compliance/fips/[AWS FIPS compliance].
+
+* When using `kernelLockdown: "integrity"`, ensure your workloads don't require loading unsigned kernel modules or modifying kernel memory.
+
+== Related resources
+
+* <<create-node-class>> - Complete Node Class configuration guide
+* <<create-node-pool>> - Node Pool configuration

--- a/latest/ug/automode/settings-auto.adoc
+++ b/latest/ug/automode/settings-auto.adoc
@@ -101,6 +101,13 @@ a|
 - Control whether workloads automatically use open ODCRs
 |<<auto-odcr>>
 
+a|
+*Node advanced security*
+
+- Enable FIPS-compliant AMIs for regulatory compliance
+- Configure kernel lockdown mode to prevent kernel modifications
+|<<auto-advanced-security>>
+
 |===
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR adds documentation for configuring the `advanceSecurity` spec for EKS Auto.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
