### PR TITLE
Add consolidateAfter to nodepools configuration

### DIFF
--- a/latest/ug/automode/auto-static-capacity.adoc
+++ b/latest/ug/automode/auto-static-capacity.adoc
@@ -160,6 +160,7 @@ spec:
     nodes: 25
 
   disruption:
+    consolidateAfter: 0s
     # Conservative disruption for production workloads
     budgets:
       - nodes: 10%
@@ -204,6 +205,7 @@ spec:
     nodes: 15
 
   disruption:
+    consolidateAfter: 0s
     budgets:
       - nodes: 25%
 ----


### PR DESCRIPTION
*Description of changes:* Add consolidateAfter to nodepools configuration because the consolidateAfter is indeed marked as required in the schema of the CRD definition,

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
