### PR TITLE
cleanup: remove note on auto instance profile prefixes

### DIFF
--- a/latest/ug/automode/create-node-class.adoc
+++ b/latest/ug/automode/create-node-class.adoc
@@ -120,9 +120,6 @@ spec:
 
   # role and instanceProfile are mutually exclusive fields.
   role: MyNodeRole  # IAM role for EC2 instances
-  # NOTE: instance profile names must start with the 'eks' prefix. this is a
-  # temporary limitation to be lifted soon.
-  # instanceProfile: eks-MyNodeInstanceProfile  # IAM instance-profile for EC2 instances
   
   subnetSelectorTerms:
     - tags:


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Removes the note about a temporary requirement that instance profiles used in EKS Auto NodeClasses have a prefix of `eks-`. This will soon no longer be the case.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
