### PR TITLE
Enhance loadbalancers migration documentation with link

### DIFF
--- a/latest/ug/automode/migrate-auto.adoc
+++ b/latest/ug/automode/migrate-auto.adoc
@@ -24,7 +24,7 @@ You can enable EKS Auto Mode on existing EKS Clusters.
 ** The https://github.com/awslabs/eks-auto-mode-ebs-migration-tool[`eks-auto-mode-ebs-migration-tool`] ({aws} Labs project) enables migration between standard EBS CSI StorageClass (`ebs.csi.aws.com`) and EKS Auto EBS CSI StorageClass (`ebs.csi.eks.amazonaws.com`). Note that migration requires deleting and re-creating existing PersistentVolumeClaim/PersistentVolume resources, so validation in a non-production environment is essential before implementation.
 * Migrating load balancers from the {aws} Load Balancer Controller to EKS Auto Mode 
 +
-You can install the {aws} Load Balancer Controller on an Amazon EKS Auto Mode cluster. Use the `IngressClass` or `loadBalancerClass` options to associate Service and Ingress resources with either the Load Balancer Controller or EKS Auto Mode. 
+You can install the {aws} Load Balancer Controller on an Amazon EKS Auto Mode cluster. Use the `IngressClass` or `loadBalancerClass` options to associate Service and Ingress resources with either the Load Balancer Controller or EKS Auto Mode. For a prescriptive guidance, refer to https://docs.aws.amazon.com/prescriptive-guidance/latest/patterns/migrate-nginx-ingress-controller-eks-auto-mode.html[`Migrate NGINX Ingress Controllers when enabling Amazon EKS Auto Mode`]
 * Migrating EKS clusters with alternative CNIs or other unsupported networking configurations
 
 [#migration-reference]


### PR DESCRIPTION
Added prescriptive guidance link for migrating NGINX Ingress Controllers to EKS Auto Mode.

*Issue #, if available:*

*Description of changes:*

AWS Prescriptive Guidance Pattern to Migrate NGINX Ingress Controllers when enabling Amazon EKS Auto Mode

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
