### PR TITLE
Update view-cluster-insights.adoc

### DIFF
--- a/latest/ug/clusters/view-cluster-insights.adoc
+++ b/latest/ug/clusters/view-cluster-insights.adoc
@@ -54,7 +54,7 @@ To see the list of insight checks performed and any relevant issues that Amazon 
 +
 [source,bash,subs="verbatim,attributes,quotes"]
 ----
-aws eks start-insight-refresh --region [.replaceable]`region-code` --cluster-name [.replaceable]`my-cluster`
+aws eks start-insights-refresh --region [.replaceable]`region-code` --cluster-name [.replaceable]`my-cluster`
 ----
 . To track the status of an insights refresh, run the following command. Replace [.replaceable]`my-cluster` with the name of your cluster.
 +


### PR DESCRIPTION
Update command to match CLI options available

*Issue #, if available:*

*Description of changes:*
- Update CLI command to match that available. Running the command currently gives and error
```
aws eks start-insight-refresh --region eu-west-2 --cluster-name eks-dev-euw2

aws: [ERROR]: argument operation: Found invalid choice 'start-insight-refresh'

Maybe you meant:

  * start-insights-refresh

usage: aws [options] <command> <subcommand> [<subcommand> ...] [parameters]
To see help text, you can run:

  aws help
  aws <command> help
  aws <command> <subcommand> help
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.