### PR TITLE
Document url-rewrite limitation for EKS automode

### DIFF
--- a/latest/ug/automode/auto-elb-example.adoc
+++ b/latest/ug/automode/auto-elb-example.adoc
@@ -224,6 +224,27 @@ kubectl delete namespace game-2048
 
 This will delete all resources in the namespace, including the deployment, service, and ingress resources.
 
+NOTE: If you have a alb.ingress.kubernetes.io/transforms.* for url-rewrite the EKS automode is not supported as of today.
+
+[source,yaml]
+----
+alb.ingress.kubernetes.io/transforms.application: |
+  [
+    {
+      "type": "url-rewrite",
+      "urlRewriteConfig": {
+        "rewrites": [
+          {
+            "regex": "^/applicationname/(.*)",
+            "replace": "/$1"
+          }
+        ]
+      }
+    }
+  ]
+
+----
+
 == What's Happening Behind the Scenes
 
 . The deployment creates 5 pods running the 2048 game


### PR DESCRIPTION
Added a note about the unsupported url-rewrite feature in EKS automode.

*Issue #, if available:* https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4433

*Description of changes:* Document url-rewrite limitation for EKS automode


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
