### PR TITLE
Correcting the storageready repair action

### DIFF
--- a/latest/ug/nodes/node-health-nma.adoc
+++ b/latest/ug/nodes/node-health-nma.adoc
@@ -478,7 +478,7 @@ The monitoring condition is `NetworkingReady` for issues in the following table 
 [#node-health-Storage]
 == Storage node health issues
 
-The monitoring condition is `StorageReady` for issues in the following table that have a severity of “Condition”.
+The monitoring condition is `StorageReady` for issues in the following table that have a severity of “Event”.
 
 [%header,cols="4"]
 |===

--- a/latest/ug/nodes/node-repair.adoc
+++ b/latest/ug/nodes/node-repair.adoc
@@ -56,8 +56,8 @@ For a detailed list of node health issues detected by the EKS node monitoring ag
 
 |StorageReady
 |StorageReady indicates whether the node's storage subsystem is functioning correctly (disks, filesystems, I/O).
-|30m
-|Replace
+|N/A
+|None
 
 |Ready
 |Ready is the standard Kubernetes condition indicating the node is healthy and ready to accept pods.


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

According to the NMA documentation : https://docs.aws.amazon.com/eks/latest/userguide/node-health-nma.html#node-health-Storage and NMA source code : https://github.com/aws/eks-node-monitoring-agent/blob/main/pkg/reasons/reasons.yaml#L341-L367, there is no "condition" for StorageReady that can trigger the replace/reboot of the instance as all the scenarios are events.

Therefore I am creating this PR to correct the docs which say that StorageReady triggers a replace in 30 mins.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
