### PR TITLE
Spell-Mistake

### DIFF
--- a/latest/ug/clusters/update-cluster.adoc
+++ b/latest/ug/clusters/update-cluster.adoc
@@ -162,7 +162,7 @@ Continue to <<step4>>.
 [source,bash,subs="verbatim,attributes"]
 ----
 aws eks update-cluster-version --name <cluster-name> \
-  --kubernetes-version <verion-number> --region <region-code>
+  --kubernetes-version <version-number> --region <region-code>
 ----
 +
 An example output is as follows.


### PR DESCRIPTION
Corrected the spell-mistake of "version" in aws eks CLI Command

*Issue #, if available:*
There was a spell-mistake for aws eks update command.

*Description of changes:*
Corrected the spell, as was assisting customer today morning and found this.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
