### PR TITLE
Add step to install Gateway API CRDs

### DIFF
--- a/latest/ug/networking/lbc-helm.adoc
+++ b/latest/ug/networking/lbc-helm.adoc
@@ -33,6 +33,7 @@ In the following steps, replace the example values with your own values.
 Before starting this tutorial, you must complete the following steps:
 
 * Create an Amazon EKS cluster. To create one, see <<getting-started>>.
+* Install the Gateway API CRDs on the Amazon EKS cluster.
 * Install https://helm.sh/docs/helm/helm_install/[Helm] on your local machine.
 * Make sure that your Amazon VPC CNI plugin for Kubernetes, `kube-proxy`, and CoreDNS add-ons are at the minimum versions listed in <<boundserviceaccounttoken-validated-add-on-versions,Service account tokens>>.
 * Learn about {aws} Elastic Load Balancing concepts. For more information, see the link:elasticloadbalancing/latest/userguide/[Elastic Load Balancing User Guide,type="documentation"].


### PR DESCRIPTION
This refers to https://github.com/kubernetes-sigs/aws-load-balancer-controller/issues/4651.

I don't know how adoc's links work. This can link to https://gateway-api.sigs.k8s.io/guides/getting-started/#installing-gateway-api. Or I hope AWS EKS can be provided with Gateway API CRDs installed out-of-the-box.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
