### PR TITLE
fix: minor typo in lbc-manifest.adoc

### DIFF
--- a/latest/ug/networking/lbc-manifest.adoc
+++ b/latest/ug/networking/lbc-manifest.adoc
@@ -299,7 +299,7 @@ curl -Lo v2.14.1_ingclass.yaml https://github.com/kubernetes-sigs/aws-load-balan
 +
 [source,shell,subs="verbatim,attributes"]
 ----
-kubectl apply -f v2_14_1_ingclass.yaml
+kubectl apply -f v2.14.1_ingclass.yaml
 ----
 
 


### PR DESCRIPTION
*Issue #, if available:*
The docs instructs reader to download a file via curl and then run kubectl apply against that. The filename doesn't match on the two commands and this PR fixes that.

*Description of changes:*
Edited underscores to dots.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
