### PR TITLE
Fix insecure link and missing space in learn-eks.adoc

### DIFF
--- a/latest/ug/getting-started/learn-eks.adoc
+++ b/latest/ug/getting-started/learn-eks.adoc
@@ -122,7 +122,7 @@ The link:tutorials[{aws} Tutorials,type="marketing"] site publishes a few Amazon
 [#developers-workshop]
 == Developers Workshop
 
-If you are a software developer, looking to create or refactor applications to run on Amazon EKS, the http://developers.eksworkshop.com[Amazon EKS Developers workshop]is a good place to start. The workshop not only helps you build containerized applications, but also helps you deploy those containers to a container registry (link:ecr/[ECR,type="marketing"]) and from there to an Amazon EKS cluster.
+If you are a software developer, looking to create or refactor applications to run on Amazon EKS, the https://developers.eksworkshop.com[Amazon EKS Developers workshop] is a good place to start. The workshop not only helps you build containerized applications, but also helps you deploy those containers to a container registry (link:ecr/[ECR,type="marketing"]) and from there to an Amazon EKS cluster.
 
 Start with the https://developers.eksworkshop.com/docs/python/[Amazon EKS Python Workshop] to go through the process of refactoring a python application, then set up your development environment to prepare for deploying the application. Step through sections on Containers, Kubernetes, and Amazon EKS to prepare to run your containerized applications in those environments.
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Fixed insecure `http://` link to `https://` on line 125 of `learn-eks.adoc`, and added a missing space after the link text. Line 127 of the same file already uses `https://` for the same domain.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
