### PR TITLE
Update stale Kinesis Data Firehose references to Amazon Data Firehose

### DIFF
--- a/latest/ug/automode/auto-managed-component-logs.adoc
+++ b/latest/ug/automode/auto-managed-component-logs.adoc
@@ -35,13 +35,13 @@ Setting up logging requires three steps:
 2. Create a delivery destination using PutDeliveryDestination
 3. Create a delivery to connect the source and destination using CreateDelivery
 
-You can configure the details of the destination for Auto Mode's logs using the deliveryDestinationConfiguration object in the CloudWatch PutDeliveryDestination API. It takes the ARN of either a CloudWatch log group, S3 bucket, or Kinesis Data Firehose delivery stream.
+You can configure the details of the destination for Auto Mode's logs using the deliveryDestinationConfiguration object in the CloudWatch PutDeliveryDestination API. It takes the ARN of either a CloudWatch log group, S3 bucket, or Amazon Data Firehose delivery stream.
 
 You can configure a single Auto Mode capability (delivery source) to send logs to multiple destinations by creating multiple deliveries. You can also create multiple deliveries to configure multiple delivery sources to send logs to the same delivery destination.
 
 === IAM permissions
 
-Depending on the destination selected, you may need to configure IAM Policies or Roles for the CloudWatch log group, S3 bucket, and Kinesis Data Firehose to ensure successful log delivery. Additionally, if you're sending logs across {aws} accounts, you'll need to use the PutDeliveryDestinationPolicy API to configure an IAM policy that allows delivery to the destination. See the link:AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-logs-infrastructure-V2-CloudWatchLogs[CloudWatch Vended Logs permissions documentation,type="documentation"] for additional information.
+Depending on the destination selected, you may need to configure IAM Policies or Roles for the CloudWatch log group, S3 bucket, and Amazon Data Firehose to ensure successful log delivery. Additionally, if you're sending logs across {aws} accounts, you'll need to use the PutDeliveryDestinationPolicy API to configure an IAM policy that allows delivery to the destination. See the link:AmazonCloudWatch/latest/logs/AWS-logs-and-resource-policy.html#AWS-logs-infrastructure-V2-CloudWatchLogs[CloudWatch Vended Logs permissions documentation,type="documentation"] for additional information.
 
 == Viewing your logs
 

--- a/latest/ug/workloads/community-addons.adoc
+++ b/latest/ug/workloads/community-addons.adoc
@@ -229,7 +229,7 @@ External DNS permissions can be reduced to `route53:ChangeResourceRecordSets`, `
 [#fluent-bit]
 === Fluent Bit
 
-Fluent Bit is a lightweight and high-performance log processor and forwarder. It allows you to collect data/logs from different sources, unify them, and send them to multiple destinations including Amazon CloudWatch Logs, Amazon S3, and Amazon Kinesis Data Firehose. Fluent Bit is designed with performance and resource efficiency in mind, making it ideal for Kubernetes environments.
+Fluent Bit is a lightweight and high-performance log processor and forwarder. It allows you to collect data/logs from different sources, unify them, and send them to multiple destinations including Amazon CloudWatch Logs, Amazon S3, and Amazon Data Firehose. Fluent Bit is designed with performance and resource efficiency in mind, making it ideal for Kubernetes environments.
 
 This add-on does not require IAM permissions in the default configuration. However, you may need to grant this add-on IAM permissions if you configure an {aws} output location. For more information, see <<update-addon-role>>.
 


### PR DESCRIPTION
Issue #, if available: N/A

Description of changes: Updated 3 references to "Kinesis Data Firehose" to "Amazon Data Firehose" in `auto-managed-component-logs.adoc` and `community-addons.adoc`. Amazon Kinesis Data Firehose was officially renamed to Amazon Data Firehose on February 9, 2024.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
