### PR TITLE
Update certificate lifetime from 1 year to 45 days

### DIFF
--- a/latest/ug/security/cert-signing.adoc
+++ b/latest/ug/security/cert-signing.adoc
@@ -22,7 +22,7 @@ If you want to use Amazon EKS CA for generating certificates on your clusters, y
 * Permitted key usages: Must not include usages beyond ["key encipherment", "digital signature", "server auth"]
 +
 NOTE: Client certificate signing is not supported.
-* Expiration/certificate lifetime: 1 year (default and maximum) 
+* Expiration/certificate lifetime: 45 days (default and maximum) 
 * CA bit allowed/disallowed: Not allowed
 
 


### PR DESCRIPTION
Based on the internal EKS feature update, requesting the change on the documentation.

*Issue #, if available:* 
As internally known, EKS has updated certificate lifetime from 1 year to 45 days, which has been flagged by lot of customers, that documentation is not updated. 

*Description of changes:*
Updated the value accordingly. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
