### PR TITLE
Update zone-shift.adoc to reflect Karpenter support for zonal shift i…

### DIFF
--- a/latest/ug/clusters/zone-shift.adoc
+++ b/latest/ug/clusters/zone-shift.adoc
@@ -251,7 +251,7 @@ If you are running a stateful application, you must assess its fault tolerance, 
 
 *Does this feature work with Karpenter?*
 
-Karpenter support is currently not available with ARC zonal shift and zonal autoshift in EKS. If an AZ is impaired, you can adjust the relevant Karpenter NodePool configuration by removing the unhealthy AZ so that new worker nodes are only launched in the other AZs. 
+Karpenter support is available with ARC zonal shift and zonal autoshift in EKS with https://github.com/aws/karpenter-provider-aws[Karpenter version 1.12 or greater]. 
 
 *Does this feature work with EKS Fargate?*
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Updating EKS documentation to reflect that Zonal Shift is compatible with Karpenter v1.12 or greater. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
