### PR TITLE
Add private endpoint guidance and prerequisites to Argo CD capability creation docs

### DIFF
--- a/latest/ug/capabilities/argocd-create-cli.adoc
+++ b/latest/ug/capabilities/argocd-create-cli.adoc
@@ -12,6 +12,7 @@ This topic describes how to create an Argo CD capability using the {aws} CLI.
 * *{aws} CLI* – Version `{auto-cli-v2-version}` or later. To check your version, run `aws --version`. For more information, see link:cli/latest/userguide/cli-chap-install.html[Installing, updating, and uninstalling the {aws} CLI,type="documentation"] in the {aws} Command Line Interface User Guide.
 * *`kubectl`* – A command line tool for working with Kubernetes clusters. For more information, see <<install-kubectl>>.
 * *{aws} Identity Center configured* – Argo CD requires {aws} Identity Center for authentication. Local users are not supported. If you don't have {aws} Identity Center set up, see link:singlesignon/latest/userguide/getting-started.html[Getting started with {aws} Identity Center,type="documentation"] to create an Identity Center instance, and link:singlesignon/latest/userguide/addusers.html[Add users,type="documentation"] and link:singlesignon/latest/userguide/addgroups.html[Add groups,type="documentation"] to create users and groups for Argo CD access.
+* *At least one user or group in {aws} Identity Center* – You must have at least one user or group configured in your Identity Center instance to assign Argo CD RBAC role mappings and provide access to the Argo CD UI.
 
 == Step 1: Create an IAM Capability Role
 
@@ -53,6 +54,47 @@ If you plan to use the optional integrations with {aws} Secrets Manager or {aws}
 For IAM policy examples and configuration guidance, see <<integration-secrets-manager>> and <<integration-codeconnections>>.
 ====
 
+== (Optional) Configure a private endpoint
+
+By default, the Argo CD UI and API endpoint are publicly accessible over the internet. If you need to restrict access, you can configure a VPC endpoint.
+This is recommended for environments with strict network security requirements.
+
+=== Create a VPC endpoint for EKS Capabilities
+
+Create an interface VPC endpoint for the EKS Capabilities service in your VPC.
+Replace [.replaceable]`vpc-id`, [.replaceable]`subnet-id-1`, [.replaceable]`subnet-id-2`, [.replaceable]`sg-id`, and [.replaceable]`region-code` with your own values:
+
+[source,bash,subs="verbatim,attributes,quotes"]
+----
+aws ec2 create-vpc-endpoint \
+  --vpc-endpoint-type Interface \
+  --service-name com.amazonaws.[.replaceable]`region-code`.eks-capabilities \
+  --vpc-id [.replaceable]`vpc-xxxxxxxx` \
+  --subnet-ids [.replaceable]`subnet-xxxxxxxx` [.replaceable]`subnet-yyyyyyyy` \
+  --security-group-ids [.replaceable]`sg-xxxxxxxx` \
+  --region [.replaceable]`region-code`
+----
+
+[NOTE]
+====
+* The subnets should be in different Availability Zones for high availability.
+* The security group must allow inbound HTTPS (port 443) traffic from the networks that need to access the Argo CD UI and API.
+* Note the VPC endpoint ID returned by this command—you'll need it when creating the capability.
+====
+
+=== Verify the VPC endpoint is available
+
+[source,bash,subs="verbatim,attributes,quotes"]
+----
+aws ec2 describe-vpc-endpoints \
+  --vpc-endpoint-ids [.replaceable]`vpce-xxxxxxxx` \
+  --query 'VpcEndpoints[0].State' \
+  --output text \
+  --region [.replaceable]`region-code`
+----
+
+Wait until the state shows `available` before proceeding.
+
 == Step 2: Create the Argo CD capability
 
 Create the Argo CD capability resource on your cluster.
@@ -85,6 +127,40 @@ aws eks create-capability \
   --type ARGOCD \
   --role-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/ArgoCDCapabilityRole \
   --delete-propagation-policy RETAIN \
+  --configuration '{
+    "argoCd": {
+      "awsIdc": {
+        "idcInstanceArn": "'$IDC_INSTANCE_ARN'",
+        "idcRegion": "'[.replaceable]`idc-region-code`'"
+      },
+      "rbacRoleMappings": [{
+        "role": "ADMIN",
+        "identities": [{
+          "id": "'$IDC_USER_ID'",
+          "type": "SSO_USER"
+        }]
+      }]
+    }
+  }'
+----
+
+If you configured a VPC endpoint for private access, include the `network-configuration` parameter to create the capability with a private endpoint.
+Replace [.replaceable]`vpce-xxxxxxxx` with your VPC endpoint ID:
+
+[source,bash,subs="verbatim,attributes,quotes"]
+----
+aws eks create-capability \
+  --region [.replaceable]`region-code` \
+  --cluster-name [.replaceable]`my-cluster` \
+  --capability-name my-argocd \
+  --type ARGOCD \
+  --role-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/ArgoCDCapabilityRole \
+  --delete-propagation-policy RETAIN \
+  --network-configuration '{
+    "elasticNetworkInterfaces": {
+      "vpcEndpointId": "'[.replaceable]`vpce-xxxxxxxx`'"
+    }
+  }' \
   --configuration '{
     "argoCd": {
       "awsIdc": {

--- a/latest/ug/capabilities/argocd-create-console.adoc
+++ b/latest/ug/capabilities/argocd-create-console.adoc
@@ -10,6 +10,7 @@ This topic describes how to create an Argo CD capability using the {aws-manageme
 == Prerequisites
 
 * *{aws} Identity Center configured* – Argo CD requires {aws} Identity Center for authentication. Local users are not supported. If you don't have {aws} Identity Center set up, see link:singlesignon/latest/userguide/getting-started.html[Getting started with {aws} Identity Center,type="documentation"] to create an Identity Center instance, and link:singlesignon/latest/userguide/addusers.html[Add users,type="documentation"] and link:singlesignon/latest/userguide/addgroups.html[Add groups,type="documentation"] to create users and groups for Argo CD access.
+* *At least one user or group in {aws} Identity Center* – You must have at least one user or group configured in your Identity Center instance to assign Argo CD RBAC role mappings and provide access to the Argo CD UI.
 
 == Create the Argo CD capability
 
@@ -45,6 +46,25 @@ For IAM policy examples and configuration guidance, see <<integration-secrets-ma
 .. Select *Enable {aws} Identity Center integration*.
 .. Choose your Identity Center instance from the dropdown.
 .. Configure role mappings for RBAC by assigning users or groups to Argo CD roles (ADMIN, EDITOR, or VIEWER)
+
+. *(Optional) Configure private endpoint*:
++
+By default, the Argo CD UI and API endpoint are publicly accessible over the internet. If you need to restrict access, you can configure a VPC endpoint.
+This is recommended for environments with strict network security requirements.
++
+.. Before creating the capability, create an interface VPC endpoint for the `com.amazonaws.<region>.eks-capabilities` service in your VPC. The VPC endpoint should:
++
+*** Be associated with subnets in different Availability Zones for high availability
+*** Have a security group that allows inbound HTTPS (port 443) traffic from the networks that need to access the Argo CD UI and API
+*** For more details on creating and customizing VPC endpoints, see link:vpc/latest/privatelink/create-interface-endpoint.html[Create a VPC endpoint,type="documentation"] in the {aws} PrivateLink Guide.
++
+.. In the *Argo CD endpoint access - _optional_* section of the Argo CD capability creation page, select *Private*.
+.. Choose the VPC endpoint you created from the dropdown.
++
+[NOTE]
+====
+When private endpoint is enabled, the Argo CD UI and API are only accessible through the VPC endpoint. Users must be connected to the VPC (or a peered network) to access the Argo CD interface.
+====
 
 . Choose *Create*.
 

--- a/latest/ug/capabilities/argocd-create-eksctl.adoc
+++ b/latest/ug/capabilities/argocd-create-eksctl.adoc
@@ -13,6 +13,11 @@ The following steps require eksctl version `0.220.0` or later.
 To check your version, run `eksctl version`.
 ====
 
+== Prerequisites
+
+* *{aws} Identity Center configured* – Argo CD requires {aws} Identity Center for authentication. Local users are not supported. If you don't have {aws} Identity Center set up, see link:singlesignon/latest/userguide/getting-started.html[Getting started with {aws} Identity Center,type="documentation"] to create an Identity Center instance, and link:singlesignon/latest/userguide/addusers.html[Add users,type="documentation"] and link:singlesignon/latest/userguide/addgroups.html[Add groups,type="documentation"] to create users and groups for Argo CD access.
+* *At least one user or group in {aws} Identity Center* – You must have at least one user or group configured in your Identity Center instance to assign Argo CD RBAC role mappings and provide access to the Argo CD UI.
+
 == Step 1: Create an IAM Capability Role
 
 Create a trust policy file:
@@ -71,6 +76,47 @@ aws identitystore list-users \
 
 Note these values - you'll need them in the next step.
 
+== (Optional) Configure a private endpoint
+
+By default, the Argo CD UI and API endpoint are publicly accessible over the internet. If you need to restrict access, you can configure a VPC endpoint.
+This is recommended for environments with strict network security requirements.
+
+=== Create a VPC endpoint for EKS Capabilities
+
+Create an interface VPC endpoint for the EKS Capabilities service in your VPC.
+Replace [.replaceable]`vpc-id`, [.replaceable]`subnet-id-1`, [.replaceable]`subnet-id-2`, [.replaceable]`sg-id`, and [.replaceable]`region-code` with your own values:
+
+[source,bash,subs="verbatim,attributes,quotes"]
+----
+aws ec2 create-vpc-endpoint \
+  --vpc-endpoint-type Interface \
+  --service-name com.amazonaws.[.replaceable]`region-code`.eks-capabilities \
+  --vpc-id [.replaceable]`vpc-xxxxxxxx` \
+  --subnet-ids [.replaceable]`subnet-xxxxxxxx` [.replaceable]`subnet-yyyyyyyy` \
+  --security-group-ids [.replaceable]`sg-xxxxxxxx` \
+  --region [.replaceable]`region-code`
+----
+
+[NOTE]
+====
+* The subnets should be in different Availability Zones for high availability.
+* The security group must allow inbound HTTPS (port 443) traffic from the networks that need to access the Argo CD UI and API.
+* Note the VPC endpoint ID returned by this command—you'll need it when creating the capability.
+====
+
+=== Verify the VPC endpoint is available
+
+[source,bash,subs="verbatim,attributes,quotes"]
+----
+aws ec2 describe-vpc-endpoints \
+  --vpc-endpoint-ids [.replaceable]`vpce-xxxxxxxx` \
+  --query 'VpcEndpoints[0].State' \
+  --output text \
+  --region [.replaceable]`region-code`
+----
+
+Wait until the state shows `available` before proceeding.
+
 == Step 3: Create an eksctl configuration file
 
 Create a file named `argocd-capability.yaml` with the following content.
@@ -107,6 +153,44 @@ capabilities:
 You can add multiple users or groups to the RBAC mappings.
 For groups, use `type: SSO_GROUP` and provide the group ID.
 Available roles are `ADMIN`, `EDITOR`, and `VIEWER`.
+====
+
+If you configured a VPC endpoint for private access, add the `networkConfiguration` section to the capability definition.
+Replace [.replaceable]`vpce-xxxxxxxx` with your VPC endpoint ID:
+
+[source,yaml,subs="verbatim,attributes,quotes"]
+----
+apiVersion: eksctl.io/v1alpha5
+kind: ClusterConfig
+
+metadata:
+  name: [.replaceable]`my-cluster`
+  region: [.replaceable]`cluster-region-code`
+  
+capabilities:
+  - name: my-argocd
+    type: ARGOCD
+    roleArn: arn:aws:iam::[.replaceable]`111122223333`:role/ArgoCDCapabilityRole
+    deletePropagationPolicy: RETAIN
+    networkConfiguration:
+      elasticNetworkInterfaces:
+        vpcEndpointId: [.replaceable]`vpce-xxxxxxxx`
+    configuration:
+      argocd:
+        awsIdc:
+          idcInstanceArn: [.replaceable]`arn:aws:sso:::instance/ssoins-123abc`
+          idcRegion: [.replaceable]`idc-region-code`
+        rbacRoleMappings:
+          - role: ADMIN
+            identities:
+              - id: [.replaceable]`38414300-1041-708a-01af-5422d6091e34`
+                type: SSO_USER
+----
+
+[NOTE]
+====
+When private endpoint is enabled, the Argo CD UI and API are only accessible through the VPC endpoint.
+Users must be connected to the VPC (or a peered network) to access the Argo CD interface.
 ====
 
 == Step 4: Create the Argo CD capability


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Adds documentation for configuring private endpoints when creating an Argo CD managed capability, and updates prerequisites across all three creation workflows for Private endpoint configuration (all 3 files).

- Added an optional step documenting how to create a VPC interface endpoint using the `com.amazonaws.<region>.eks-capabilities` service name
- Includes guidance on VPC, subnet (multi-AZ), and security group (port 443) requirements
- Added a disclaimer that by default the Argo CD UI and API endpoint are publicly accessible, and that private endpoint configuration is needed to restrict access
- Added prerequisite: at least one user or group must exist in AWS Identity Center to assign RBAC role mappings and provide access to the Argo CD UI

**Per-file details:**

**argocd-create-cli.adoc**
- New "(Optional) Configure a private endpoint" section between Step 1 and Step 2
- Added a second `aws eks create-capability` command variant showing the `--network-configuration` parameter with `vpcEndpointId`

**argocd-create-console.adoc**
- New optional step in the creation workflow explaining how to enable private endpoint in the console UI
- Added a link to the AWS PrivateLink documentation for creating VPC endpoints

**argocd-create-eksctl.adoc**
- New "(Optional) Configure a private endpoint" section between Step 2 and Step 3
- Added a second eksctl YAML example showing the `networkConfiguration.elasticNetworkInterfaces.vpcEndpointId` field
- Added a new Prerequisites section (didn't have one before)

**Testing**

- Verified AsciiDoc structure and cross-reference formatting
- No build/render validation performed (docs-only change)