### PR TITLE
Fix upstream links on ACK Considerations page

### DIFF
--- a/latest/ug/capabilities/ack-considerations.adoc
+++ b/latest/ug/capabilities/ack-considerations.adoc
@@ -276,9 +276,8 @@ For more on deletion policies, see <<ack-concepts>>.
 
 For detailed information on using ACK:
 
-* https://aws-controllers-k8s.github.io/community/docs/user-docs/usage/[ACK usage guide^] - Creating and managing resources
-* https://aws-controllers-k8s.github.io/community/reference/[ACK API reference^] - Complete API documentation for all services
-* https://aws-controllers-k8s.github.io/community/docs/[ACK documentation^] - Comprehensive user documentation
+* https://aws-controllers-k8s.github.io/docs/api-reference[ACK API reference^] - Complete API documentation for all services
+* https://aws-controllers-k8s.github.io/docs/intro[ACK documentation^] - Comprehensive user documentation
 
 == Next steps
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This PR updates the upstream ACK links to use the new ACK docs website instead of deprecated legacy ACK docs. IN the case of "ACK usage guide" the link has been removed as it returned a 404 error.

- Remove broken "ACK usage guide" link (Resolved to 404 error page)
- Update "ACK API Reference" to use new ACK docs website instead of directing to deprecated ACK docs. Note, not strictly necessary as this link was being re-directed to the new website.
- Update "ACK documentation" link to use new ACK docs website instead of deprecated ACK docs.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
