### PR TITLE
Add ec2:DescribeSubnets and ec2:DescribeSecurityGroups to CNI IPv6 policy

### DIFF
--- a/latest/ug/iam_policies/AmazonEKS_CNI_IPv6_Policy.json
+++ b/latest/ug/iam_policies/AmazonEKS_CNI_IPv6_Policy.json
@@ -20,6 +20,14 @@
             "Resource": [
                 "{arn-aws}ec2:*:*:network-interface/*"
             ]
+        },
+        {
+            "Effect": "Allow",
+            "Action": [
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups"
+            ],
+            "Resource": "*"
         }
     ]
 }

--- a/latest/ug/iam_policies/AmazonEKS_CNI_IPv6_Policy.json
+++ b/latest/ug/iam_policies/AmazonEKS_CNI_IPv6_Policy.json
@@ -8,7 +8,9 @@
                 "ec2:DescribeInstances",
                 "ec2:DescribeTags",
                 "ec2:DescribeNetworkInterfaces",
-                "ec2:DescribeInstanceTypes"
+                "ec2:DescribeInstanceTypes",
+                "ec2:DescribeSubnets",
+                "ec2:DescribeSecurityGroups"
             ],
             "Resource": "*"
         },
@@ -20,14 +22,6 @@
             "Resource": [
                 "{arn-aws}ec2:*:*:network-interface/*"
             ]
-        },
-        {
-            "Effect": "Allow",
-            "Action": [
-                "ec2:DescribeSubnets",
-                "ec2:DescribeSecurityGroups"
-            ],
-            "Resource": "*"
         }
     ]
 }


### PR DESCRIPTION
## Description

Resolves https://github.com/awsdocs/amazon-eks-user-guide/issues/1247

The Amazon VPC CNI plugin for Kubernetes requires the `ec2:DescribeSubnets` and `ec2:DescribeSecurityGroups` permissions as of [v1.22.1](https://github.com/aws/amazon-vpc-cni-k8s/releases/tag/v1.22.1).

This adds those permissions to the `IPv6` IAM policy example (`latest/ug/iam_policies/AmazonEKS_CNI_IPv6_Policy.json`), used by the [Configure Amazon VPC CNI plugin to use IRSA](https://docs.aws.amazon.com/eks/latest/userguide/cni-iam-role.html#cni-iam-role-create-ipv6-policy ) topic.

(I think! I don't know how the snippet system works, so I'm guessing this is the correct place to make the change).

The goal is to update the IAM snippet at the very bottom of this page: https://github.com/awsdocs/amazon-eks-user-guide/blob/mainline/latest/ug/networking/cni-iam-role.adoc

```json
{
    "Effect": "Allow",
    "Action": [
        "ec2:DescribeSubnets",
        "ec2:DescribeSecurityGroups"
    ],
    "Resource": "*"
}
```

🤖 Generated with [Claude Code](https://claude.com/claude-code) (yes, sorry, I made claude do something as simple as this. i hate it too.)