### PR TITLE
Fix instance label prefix for Auto Mode NodePool example

### DIFF
--- a/latest/ug/ml/ml-node-pools.adoc
+++ b/latest/ug/ml/ml-node-pools.adoc
@@ -298,7 +298,7 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["on-demand"]
-        - key: "karpenter.k8s.aws/instance-family"
+        - key: "eks.amazonaws.com/instance-family"
           operator: In
           values: ["g6e"]
         - key: "topology.kubernetes.io/zone"
@@ -405,7 +405,7 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["reserved"]
-        - key: "karpenter.k8s.aws/instance-family"
+        - key: "eks.amazonaws.com/instance-family"
           operator: In
           values: ["p5", "p5e", "p5en", "p4d"]
       taints:
@@ -517,7 +517,7 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["reserved", "on-demand"]
-        - key: "karpenter.k8s.aws/instance-family"
+        - key: "eks.amazonaws.com/instance-family"
           operator: In
           values: ["p5", "g6e"]
         - key: "topology.kubernetes.io/zone"
@@ -606,10 +606,10 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["on-demand"]
-        - key: "karpenter.k8s.aws/instance-family"
+        - key: "eks.amazonaws.com/instance-family"
           operator: In
           values: ["g6", "g6e", "g7e"]
-        - key: "karpenter.k8s.aws/instance-gpu-manufacturer"
+        - key: "eks.amazonaws.com/instance-gpu-manufacturer"
           operator: In
           values: ["nvidia"]
       taints:
@@ -696,10 +696,10 @@ spec:
         - key: "karpenter.sh/capacity-type"
           operator: In
           values: ["spot"]
-        - key: "karpenter.k8s.aws/instance-family"
+        - key: "eks.amazonaws.com/instance-family"
           operator: In
           values: ["g6", "g6e", "g7e"]
-        - key: "karpenter.k8s.aws/instance-gpu-manufacturer"
+        - key: "eks.amazonaws.com/instance-gpu-manufacturer"
           operator: In
           values: ["nvidia"]
       taints:


### PR DESCRIPTION
Fix instance label prefix for Auto Mode NodePool example

*Issue #, if available:*
N/A

*Description of changes:*
The sample NodePool manifest for Auto Mode uses incorrect instance label prefixes:

- karpenter.k8s.aws/instance-family → eks.amazonaws.com/instance-family
- karpenter.k8s.aws/instance-gpu-manufacturer → eks.amazonaws.com/instance-gpu-manufacturer

This PR corrects the prefix to match the Auto Mode label convention.